### PR TITLE
Enable the PSA feature for all targets

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -8,7 +8,8 @@
     "target_overrides": {
         "*": {
              "platform.stdio-convert-newlines": true,
-             "platform.stdio-baud-rate": 115200
+             "platform.stdio-baud-rate": 115200,
+             "target.features_add": ["PSA"]
         },
         "ARM_MUSCA_A1": {
             "app.os-thread-user-stack-size": 8096


### PR DESCRIPTION
This application requires PSA, so enable the PSA feature for all
targets. We do this so we can run this application on targets that don't
have PSA enabled by default, leaving it up to applications to turn on
the feature if desired.