### PR TITLE
Add Firmware framework PSA compliance test support

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -228,7 +228,9 @@ def _run_cmake_build(cmake_build_dir, args, tgt, tfm_config):
         elif args.suite == 'PROTECTED_STORAGE':
             cmake_cmd.append('-DPSA_API_TEST_PROTECTED_STORAGE=ON')
         elif args.suite == 'STORAGE':
-             cmake_cmd.append('-DPSA_API_TEST_STORAGE=ON')
+            cmake_cmd.append('-DPSA_API_TEST_STORAGE=ON')
+        elif args.suite == 'IPC':
+            cmake_cmd.append('-DPSA_API_TEST_IPC=ON')
 
     cmake_cmd.append('..')
 

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -50,7 +50,8 @@ PSA_SUITE_CHOICES = [
     'INITIAL_ATTESTATION',
     'PROTECTED_STORAGE',
     'INTERNAL_TRUSTED_STORAGE',
-    'STORAGE']
+    'STORAGE',
+    'IPC']
 
 ROOT = abspath(dirname(__file__))
 mbed_path = join(ROOT, "mbed-os")


### PR DESCRIPTION
The IPC suite is used to run firmware framework tests for the
following targets:
* ARM_MUSCA_A
* ARM_MUSCA_B1
Only Level 1 PSA isolation is supported, with NO dynamic memory
functions available to secure partition.
