### PR TITLE
Update application configuration: rtos properties

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,17 +1,15 @@
 {
-    "config": {
-        "os-mutex-num": 4,
-        "os-semaphore-num": 4,
-        "os-thread-num": 9,
-        "os-thread-user-stack-size": 8096
-    },
     "target_overrides": {
         "*": {
              "platform.stdio-convert-newlines": true,
-             "platform.stdio-baud-rate": 115200
+             "platform.stdio-baud-rate": 115200,
+             "rtos.mutex-num": 4,
+             "rtos.semaphore-num": 4,
+             "rtos.thread-num": 9,
+             "rtos.thread-user-stack-size": 8096
         },
         "CY8CKIT_064S2_4343W": {
-            "app.os-thread-user-stack-size": 16384
+            "rtos.thread-user-stack-size": 16384
         }
     },
     "macros": [


### PR DESCRIPTION
Override rtos properties for mutex, semaphores, number of threads and
user thread stack instead defining application specific ones.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>