### PR TITLE
Rename `ARM_MUSCA_A` to `ARM_MUSCA_A1` target

### DIFF
--- a/build_psa_compliance.py
+++ b/build_psa_compliance.py
@@ -33,7 +33,7 @@ logging.basicConfig(level=logging.INFO,
 ROOT_TEST_LIB = join(ROOT, "test", "lib")
 
 PSA_API_TARGETS = {
-    "ARM_MUSCA_A": ["armv8m_ml", "tgt_dev_apis_tfm_musca_a",
+    "ARM_MUSCA_A1": ["armv8m_ml", "tgt_dev_apis_tfm_musca_a",
                     "tgt_ff_tfm_musca_a"],
     "ARM_MUSCA_B1": ["armv8m_ml", "tgt_dev_apis_tfm_musca_b1",
                     "tgt_ff_tfm_musca_b1"],


### PR DESCRIPTION
Sync with Mbed OS target naming convention.

Signed-off-by: Vikas Katariya <vikas.katariya@arm.com>