### PR TITLE
Remove PSA blinky example

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,6 @@
 
 // Toggle only one appropriate test.
 #define RUN_REGRESSION_TESTS        1
-#define RUN_BLINKY_EXAMPLE          0
 #define RUN_PSA_COMPLIANCE_TESTS    0
 
 #include "mbed.h"
@@ -63,34 +62,3 @@ int main(void)
 }
 
 #endif //RUN_PSA_COMPLIANCE_TESTS
-
-#if RUN_BLINKY_EXAMPLE
-
-#include "platform/mbed_thread.h"
-#include "psa/client.h"
-
-#define BLINKING_RATE_MS                                                    3000
-
-int main(void)
-{
-    uint32_t count = 0;
-
-    DigitalOut led(LED1);
-
-    printf("PSA Framework Version : %ld\r\n", psa_framework_version());
-
-    while (true)
-    {
-        led = !led;
-
-        thread_sleep_for(BLINKING_RATE_MS);
-
-        // Print only after (BLINKING_RATE_MS * 10) milliseconds.
-        if ((count++ % 10) == 0)
-        {
-            printf("Executing from NS Core... LED Blink rate : %d ms\r\n", BLINKING_RATE_MS);
-        }
-    }
-}
-
-#endif //RUN_BLINKY_EXAMPLE


### PR DESCRIPTION
We now have https://github.com/ARMmbed/mbed-os-example-psa.git to hold
this example separately from the Mbed OS TF-M regression tests. This
will help this repo remain focused on regression testing.