### PR TITLE
config: Enable experimental API

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -6,7 +6,10 @@
              "rtos.mutex-num": 4,
              "rtos.semaphore-num": 4,
              "rtos.thread-num": 9,
-             "rtos.thread-user-stack-size": 8096
+             "rtos.thread-user-stack-size": 8096,
+             "target.features_add": [
+                 "EXPERIMENTAL_API"
+             ]
         },
         "CY8CKIT_064S2_4343W": {
             "rtos.thread-user-stack-size": 16384


### PR DESCRIPTION
PSA is an experimental API currently, so, as of Mbed OS 6, to use PSA
one must enable the EXPERIMENTAL_API option in their Mbed OS config.