### PR TITLE
config: Add support for experimental feature

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -40,7 +40,8 @@ logging.basicConfig(level=logging.INFO,
                     format='[Build-TF-M] %(asctime)s: %(message)s.',
                     datefmt='%H:%M:%S')
 
-VERSION_FILE_PATH = join(mbed_path, 'features/FEATURE_PSA/TARGET_TFM')
+VERSION_FILE_PATH = join(mbed_path,
+                    'features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM')
 TC_DICT = {"ARMCLANG": "ARMC6",
            "GNUARM": "GCC_ARM"}
 

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -56,7 +56,8 @@ PSA_SUITE_CHOICES = [
 ROOT = abspath(dirname(__file__))
 mbed_path = join(ROOT, "mbed-os")
 sys.path.insert(0, mbed_path)
-TF_M_BUILD_DIR = join(mbed_path, 'features/FEATURE_PSA/TARGET_TFM/TARGET_IGNORE')
+TF_M_BUILD_DIR = join(mbed_path,
+    'features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_IGNORE')
 POPEN_INSTANCE = None
 
 def are_dependencies_installed():

--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -56,23 +56,23 @@
         "common": [
             {
                 "src": "install/export/tfm/src/tfm_crypto_ipc_api.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/src/tfm_crypto_ipc_api.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/src/tfm_crypto_ipc_api.c"
             },
             {
                 "src": "install/export/tfm/src/tfm_initial_attestation_ipc_api.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/src/tfm_initial_attestation_ipc_api.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/src/tfm_initial_attestation_ipc_api.c"
             },
             {
                 "src": "install/export/tfm/src/tfm_sst_ipc_api.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/src/tfm_sst_ipc_api.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/src/tfm_sst_ipc_api.c"
             },
             {
                 "src": "install/export/tfm/src/tfm_its_ipc_api.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/src/tfm_its_ipc_api.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/src/tfm_its_ipc_api.c"
             },
             {
                 "src": "install/export/tfm/src/tfm_platform_ipc_api.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/src/tfm_platform_ipc_api.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/src/tfm_platform_ipc_api.c"
             },
             {
                 "src": "bl2/ext/mcuboot/scripts/assemble.py",
@@ -96,47 +96,47 @@
             },
             {
                 "src": "install/export/tfm/include",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/include"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/include"
             },
             {
                 "src": "install/export/tfm/include/psa",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/include/psa"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/include/psa"
             },
             {
                 "src": "install/export/tfm/include/psa_manifest",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/include/psa_manifest"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/include/psa_manifest"
             }
         ],
         "v8-m": [
             {
                 "src": "install/export/tfm/src/tfm_psa_ns_api.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_V8M/src/tfm_psa_ns_api.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_V8M/src/tfm_psa_ns_api.c"
             },
             {
                 "src": "install/export/tfm/src/tfm_ns_interface.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_V8M/src/tfm_ns_interface.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_V8M/src/tfm_ns_interface.c"
             }
         ],
         "dualcpu": [
             {
                 "src": "install/export/tfm/src/tfm_multi_core_api.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/tfm_multi_core_api.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/tfm_multi_core_api.c"
             },
             {
                 "src": "install/export/tfm/src/platform_ns_mailbox.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/platform_ns_mailbox.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/platform_ns_mailbox.c"
             },
             {
                 "src": "install/export/tfm/src/tfm_multi_core_psa_ns_api.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/tfm_multi_core_psa_ns_api.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/tfm_multi_core_psa_ns_api.c"
             },
             {
                 "src": "install/export/tfm/src/tfm_ns_mailbox.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/tfm_ns_mailbox.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/tfm_ns_mailbox.c"
             },
             {
                 "src": "install/export/tfm/src/platform_multicore.c",
-                "dst": "features/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/platform_multicore.c"
+                "dst": "features/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_DUALCPU/src/platform_multicore.c"
             }
         ]
     },


### PR DESCRIPTION
With Mbed OS 6.0 release, PSA is marked as experimental and all the
source is moved under `FEATURE_EXPERIMENTAL_API`.

Update file/directory paths to match new directory structure of Mbed OS

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>