### PR TITLE
Increase GET timeout in fetch_extract_cmsis_pack() in psa_builder.py

### DIFF
--- a/psa_builder.py
+++ b/psa_builder.py
@@ -192,7 +192,7 @@ def fetch_extract_cmsis_pack(name, version, dir, url):
     dest_folder = os.path.join(dir, name)
     dest = os.path.join(dest_folder, dest_file)
 
-    r = requests.get(download_url, stream=True, timeout=2.0)
+    r = requests.get(download_url, stream=True, timeout=30.0)
     with open(dest, 'wb') as f:
         chunk_len = 2 ** 20
         length = r.headers.get('content-length')


### PR DESCRIPTION
The default timeout (2.0s) is too short when working with slower networks, which makes the building process fail when trying to download CMSIS.