### PR TITLE
Clone more repos

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -87,6 +87,8 @@ def _clone_tfm_repo(commit):
         "trusted-firmware-m", dependencies["tf-m"], TF_M_BUILD_DIR
     )
     check_and_clone_repo("mbed-crypto", dependencies["tf-m"], TF_M_BUILD_DIR)
+    check_and_clone_repo("mcuboot", dependencies["tf-m"], TF_M_BUILD_DIR)
+    check_and_clone_repo("tf-m-tests", dependencies["tf-m"], TF_M_BUILD_DIR)
     check_and_clone_repo("CMSIS_5", dependencies["tf-m"], TF_M_BUILD_DIR)
     fetch_extract_cmsis_pack(
         name="CMSIS_5",

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -25,7 +25,7 @@ import logging
 import requests
 from zipfile import ZipFile
 
-upstream_tfm = "https://git.trustedfirmware.org/trusted-firmware-m.git"
+upstream_tfm = "https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git"
 mbed_tfm = "https://github.com/ARMmbed/trusted-firmware-m.git"
 
 dependencies = {

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -38,6 +38,11 @@ dependencies = {
             "mbedcrypto-3.0.1",
         ],
         "CMSIS_5": ["https://github.com/ARM-software/CMSIS_5.git", "5.5.0"],
+        "mcuboot": ["https://github.com/JuulLabs-OSS/mcuboot.git", "v1.6.0"],
+        "tf-m-tests": [
+            "https://git.trustedfirmware.org/TF-M/tf-m-tests.git",
+            "master",
+        ],
     },
     "psa-api-compliance": {
         "psa-arch-tests": [


### PR DESCRIPTION
TF-M needs more repos cloned now. This will help us when we update TF-M to a newer version

Tested by successfully building for MUSCA B1 and verifying that the new repos were cloned.
`python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM -c ConfigRegressionIPC.cmake`