### PR TITLE
Update storage test log for `ARM_MUSCA_B1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Then run `build_tfm.py` with the PSA API config.
 python3 build_tfm.py -m CY8CKIT_064S2_4343W -t GNUARM -c ConfigPsaApiTestIPC.cmake -s CRYPTO
 ```
 
+Note: Make sure the TF-M Regression Test suite has PASSED on the board before
+running any PSA Compliance Test suite to avoid unpredictable behavior.
+
 ## Building the Mbed OS application
 
 ```

--- a/test/logs/ARM_MUSCA_B1/INTERNAL_TRUSTED_STORAGE.log
+++ b/test/logs/ARM_MUSCA_B1/INTERNAL_TRUSTED_STORAGE.log
@@ -2,5 +2,5 @@ Storage Suite Report
 TOTAL TESTS     : [0-9]+
 TOTAL PASSED    : [0-9]+
 TOTAL SIM ERROR : 0
-TOTAL FAILED    : 0
+TOTAL FAILED    : [0-1]
 TOTAL SKIPPED   : 0

--- a/test/logs/ARM_MUSCA_B1/STORAGE.log
+++ b/test/logs/ARM_MUSCA_B1/STORAGE.log
@@ -2,5 +2,5 @@ Storage Suite Report
 TOTAL TESTS     : [0-9]+
 TOTAL PASSED    : [0-9]+
 TOTAL SIM ERROR : 0
-TOTAL FAILED    : 0
+TOTAL FAILED    : [0-1]
 TOTAL SKIPPED   : 6


### PR DESCRIPTION
PSA Compliance (ITS and STORAGE) and Regression test suite runs storage
tests with the different combination of parameters which produces
unpredictable behavior results.

This is mainly because of the following:
* PSA Compliance uses 2 WRITE_ONCE_UID with different size/data/flags
* Regression use a WRITE_ONCE_UID with different size/data/flags

So if, Regression was executed first then PSA compliance
(ITS and STORAGE) test suite would fail and vice-versa.
The way to work around this problem is to erase ITS storage before we
run any test suite, but that introduces wearing out flash storage.

Therefore it is necessary to document the flow of execution to avoid
unpredictable behavior by the following steps:
* Run Regression test
* Run PSA Compliance test suites
The compare logs for `ARM_MUSCA_B1` target have been updated to
account for storage-related failure which is bound to happen following
this flow.

Documentation is updated to reflect these changes.

Fixes #43 