### PR TITLE
Remove Cypress target

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Run `mbed deploy` to obtain Mbed OS for this application.
 
 ## Building TF-M
 
-We are building for the Cypress PSoC64 (`CY8CKIT_064S2_4343W`) in our example
+We are building for the ARM Musca B1 (`ARM_MUSCA_B1`) in our example
 below, but other targets can be built for by changing the `-m` option.
 
 ```
-python3 build_tfm.py -m CY8CKIT_064S2_4343W -t GNUARM
+python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM
 ```
 
 ## Building the TF-M Regression Test
@@ -32,7 +32,7 @@ Use the `-c` option to specify the config overriding the default
 `ConfigCoreIPC.cmake` config.
 
 ```
-python3 build_tfm.py -m CY8CKIT_064S2_4343W -t GNUARM -c ConfigRegressionIPC.cmake
+python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM -c ConfigRegressionIPC.cmake
 ```
 
 ## Building the PSA Compliance Test
@@ -41,13 +41,13 @@ First, run `build_psa_compliance.py` to build for a target. Different suites can
 be built using the `-s` option.
 
 ```
-python3 build_psa_compliance.py -m CY8CKIT_064S2_4343W -s CRYPTO -t GNUARM
+python3 build_psa_compliance.py -m ARM_MUSCA_B1 -s CRYPTO -t GNUARM
 ```
 
 Then run `build_tfm.py` with the PSA API config.
 
 ```
-python3 build_tfm.py -m CY8CKIT_064S2_4343W -t GNUARM -c ConfigPsaApiTestIPC.cmake -s CRYPTO
+python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM -c ConfigPsaApiTestIPC.cmake -s CRYPTO
 ```
 
 Note: Make sure the TF-M Regression Test suite has PASSED on the board before
@@ -56,7 +56,7 @@ running any PSA Compliance Test suite to avoid unpredictable behavior.
 ## Building the Mbed OS application
 
 ```
-mbed compile -m CY8CKIT_064S2_4343W -t GCC_ARM
+mbed compile -m ARM_MUSCA_B1 -t GCC_ARM
 ```
 
 ## Execute all tests for ARM_MUSCA_B1

--- a/build_psa_compliance.py
+++ b/build_psa_compliance.py
@@ -40,7 +40,6 @@ PSA_API_TARGETS = {
         "tgt_dev_apis_tfm_musca_b1",
         "tgt_ff_tfm_musca_b1",
     ],
-    "CY8CKIT_064S2_4343W": ["armv7m", "tgt_dev_apis_tfm_psoc64"],
 }
 
 
@@ -304,14 +303,6 @@ def _main():
     signal.signal(signal.SIGINT, exit_gracefully)
     parser = _get_parser()
     args = parser.parse_args()
-
-    # Issue : https://github.com/ARMmbed/mbed-os-tf-m-regression-tests/issues/11
-    # There is no support for this target to run Firmware Framework tests
-    if args.suite == "IPC" and args.mcu == "CY8CKIT_064S2_4343W":
-        logging.info(
-            "%s config is not supported for %s target" % (args.suite, args.mcu)
-        )
-        return
 
     if not isdir(TF_M_BUILD_DIR):
         os.mkdir(TF_M_BUILD_DIR)

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -14,9 +14,6 @@
              "target.features_add": [
                  "EXPERIMENTAL_API"
              ]
-        },
-        "CY8CKIT_064S2_4343W": {
-            "rtos.thread-user-stack-size": 16384
         }
     },
     "macros": [

--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -26,16 +26,6 @@
                 "dst": "targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/image_macros_preprocessed_s.c"
             }
         ],
-        "CY8CKIT_064S2_4343W": [
-            {
-                "src": "install/export/platform/ext/target/cypress/psoc64/partition/flash_layout.h",
-                "dst": "targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/partition/flash_layout.h"
-            },
-            {
-                "src": "install/export/platform/ext/target/cypress/psoc64/partition/region_defs.h",
-                "dst": "targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/partition/region_defs.h"
-            }
-        ],
         # List of files that should not be copied to Mbed OS even though they are covered by directory rules
         # in the next sections.
         # This feature keeps the yaml file small and tidy by allowing folder rules and list of files to be excluded.
@@ -146,28 +136,6 @@
                 "dst": "tfm/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device/tfm_peripherals_def.h"
             }
          ],
-        "CY8CKIT_064S2_4343W": [
-            {
-                "src": "platform/ext/target/cypress/psoc64/Device/Source/device_definition.c",
-                "dst": "tfm/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/device_definition.c"
-            },
-            {
-                "src": "platform/ext/target/cypress/psoc64/Device/Include/device_definition.h",
-                "dst": "tfm/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/device_definition.h"
-            },
-            {
-                "src": "platform/ext/target/cypress/psoc64/Device/Include/platform_base_address.h",
-                "dst": "tfm/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/platform_base_address.h"
-            },
-            {
-                "src": "platform/ext/target/cypress/psoc64/tfm_peripherals_def.h",
-                "dst": "tfm/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/tfm_peripherals_def.h"
-            },
-            {
-                "src": "platform/ext/target/cypress/psoc64/Device/Include/platform_irq.h",
-                "dst": "tfm/targets/TARGET_Cypress/TARGET_PSOC6/TARGET_CY8CKIT_064S2_4343W/device/COMPONENT_CM4/platform_irq.h"
-            }
-        ],
         "common": [
             {
                 "src": "platform/include/tfm_plat_defs.h",


### PR DESCRIPTION
`CY8CKIT_064S2_4343W` target is not supported in Mbed OS, therefore removing it.

Fixes #11 