### PR TITLE
psa_builder.py: catch command not found error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Black Python Code Formatter
       uses: lgeiger/black-action@v1.0.1
       with:
-        args: ". -l 79 --check"
+        args: ". -l 79 --diff --color --check"
 

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -151,9 +151,13 @@ def run_cmd_and_return(command, output=False):
 
     global POPEN_INSTANCE
     with open(os.devnull, "w") as fnull:
-        POPEN_INSTANCE = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=fnull
-        )
+        try:
+            POPEN_INSTANCE = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=fnull
+            )
+        except FileNotFoundError:
+            logging.error("Command not found: " + command[0])
+            return -1
 
         std_out, __ = POPEN_INSTANCE.communicate()
         retcode = POPEN_INSTANCE.returncode


### PR DESCRIPTION
@ARMmbed/mbed-os-security 

Without catching this exception, `are_dependencies_installed()` won't have a chance to print a message before the script crashes.