### PR TITLE
Vagrant: fix broken dependencies

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/bionic64"
+  config.vm.box = "ubuntu/focal64"
   config.ssh.forward_agent = true
 
   config.vm.provision :shell, path: "bootstrap.sh"

--- a/vagrant/bootstrap-user.sh
+++ b/vagrant/bootstrap-user.sh
@@ -24,11 +24,12 @@ cd ~/tfm/trusted-firmware-m
 git remote add ARMmbed https://github.com/ARMmbed/trusted-firmware-m.git
 git fetch --all
 
-# Mbed tools
-python3 -m pip install mbed-cli
-
 # Regression tests
 cd
 git clone https://github.com/ARMmbed/mbed-os-tf-m-regression-tests.git
 cd ~/mbed-os-tf-m-regression-tests
 git clone https://github.com/ARMmbed/mbed-os.git
+
+# Mbed tools
+python3 -m pip install mbed-cli
+python3 -m pip install -r mbed-os/requirements.txt


### PR DESCRIPTION
The default Python shipped with Ubuntu Bionic (18.04) is 3.6, but the _latest_ "python3-pip" package from Ubuntu's apt repo only works with 3.7 or newer. Even if we manually configure it to 3.7 or 3.8, we still have other Python issues, possibly due to 3.6 preexisting packages in the system.

This PR simply switches to Ubuntu Focal (20.04) which is the latest LTS. It also installs Mbed CLI dependencies listed in `mbed-os/requirements.txt`.