### PR TITLE
build_psa_compliance.py: pass toolchain

### DIFF
--- a/build_psa_compliance.py
+++ b/build_psa_compliance.py
@@ -139,6 +139,9 @@ def _run_cmake_build(cmake_build_dir, args):
     if args.range:
         cmake_cmd.append("-DSUITE_TEST_RANGE=" + args.range)
 
+    if args.toolchain:
+        cmake_cmd.append("-DTOOLCHAIN=" + args.toolchain)
+
     retcode = run_cmd_output_realtime(cmake_cmd, cmake_build_dir)
     if retcode:
         msg = "Cmake configure failed for target %s using toolchain %s" % (


### PR DESCRIPTION
Fixes: #54

Without passing the toolchain, the default toolchain GNUARM gets selected, making it impossible to build the PSA Compliance test
with ARMCLANG.

The fix is provided by @ccli8, many thanks for that.

I've manually verified it. It won't be covered by the CI which doesn't have the Arm Compiler yet.