### PR TITLE
Workaround for regression test build with ARMCLANG

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -20,6 +20,7 @@
         "TFM_ENABLE_IRQ_TEST=1",
         "TFM_MULTI_CORE_TEST=1",
         "TFM_MULTI_CORE_MULTI_CLIENT_CALL=1",
-        "NUM_MAILBOX_QUEUE_SLOT=4"
+        "NUM_MAILBOX_QUEUE_SLOT=4",
+        "CMSDK_TIMER0_S"
     ]
 }


### PR DESCRIPTION
Fixes: #52 

Mbed applications, including the regression tests triggered by `main()`, are run on the non-secure sides. In Mbed OS we only [enable the non-secure timer](https://github.com/ARMmbed/mbed-os/blob/mbed-os-6.5.0/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device/device_cfg.h#L47-L50). However, [`plat_test.c`](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/platform/ext/target/musca_b1/plat_test.c?h=TF-Mv1.1) in trusted-firmware-m defines tests for both secure and non-secure timers. The secure timer tests are *not* eventually used by the final application, and the GCC's linker handles this to links successfully.

But it's a known behaviour that the Arm Compiler's linker (armlink) does not resolve undefined-but-unused symbols, and it fails to link the tests and complains the secure timer (`CMSDK_TIMER0_DEV_S`) is undefined:
```
Link: mbed-os-tf-m-regression-tests
[Warning] @0,0: L3912W: Option 'legacyalign' is deprecated.
[Error] @0,0: L6218E: Undefined symbol CMSDK_TIMER0_DEV_S (referred from ./test/lib/TOOLCHAIN_ARMC6/libtfm_non_secure_tests.ar(plat_test.o)).
```

As a workaround, this PR enables CMSDK_TIMER0_DEV_S by defining the macro CMSDK_TIMER0_S.

@ARMmbed/mbed-os-security In trusted-firmware-m's [vanilla device_cfg.h](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/platform/ext/target/musca_b1/Device/Config/device_cfg.h?h=TF-Mv1.1#n66), both non-secure and secure timers are always defined. In Mbed OS we only define what we need (the non-secure one), but just to fix ARMCLANG build of the tests, does it make sense to define both timers in Mbed OS, or use this PR?

@evedon @jainvikas8 This is ready for review, thanks.