### PR TITLE
Copy PSA libraries depending on toolchains

### DIFF
--- a/build_psa_compliance.py
+++ b/build_psa_compliance.py
@@ -177,8 +177,11 @@ def _copy_psa_libs(source, destination, args):
     else:
         output_dir = destination + "/"
 
+    output_dir = output_dir + "TOOLCHAIN_" + TC_DICT[args.toolchain] + "/"
+
+    output_lib_suffix = ".ar" if args.toolchain == "ARMCLANG" else ".a"
     val_nspe = join(source, "val", "val_nspe.a")
-    val_nspe_output = output_dir + "libval_nspe.a"
+    val_nspe_output = output_dir + "libval_nspe" + output_lib_suffix
     logging.info(
         "Copying %s to %s"
         % (relpath(val_nspe, source), relpath(val_nspe_output, ROOT))
@@ -186,7 +189,7 @@ def _copy_psa_libs(source, destination, args):
     shutil.copy2(val_nspe, val_nspe_output)
 
     pal_nspe = join(source, "platform", "pal_nspe.a")
-    pal_nspe_output = output_dir + "libpal_nspe.a"
+    pal_nspe_output = output_dir + "libpal_nspe" + output_lib_suffix
     logging.info(
         "Copying %s to %s"
         % (relpath(pal_nspe, source), relpath(pal_nspe_output, ROOT))
@@ -209,7 +212,7 @@ def _copy_psa_libs(source, destination, args):
     else:
         test_combine = join(source, "dev_apis", suite_folder, "test_combine.a")
 
-    test_combine_output = output_dir + "libtest_combine.a"
+    test_combine_output = output_dir + "libtest_combine" + output_lib_suffix
     logging.info(
         "Copying %s to %s"
         % (relpath(test_combine, source), relpath(test_combine_output, ROOT))


### PR DESCRIPTION
The PSA libraries should be `*.a` for GCC and `*.ar` for the Arm toolchain, in order for them to be linked to the Mbed application. (Those extensions are coded in the Mbed CLI.) They should be copied into corresponding `TOOLCHAIN_*/`.

This fixes linking failure of the PSA Compliance test (undefined symbol "val_entry") with the Arm toolchain, when compiling the Mbed application with compliance tests enabled.