### PR TITLE
vagrant: clone specific TF-M version tag

### DIFF
--- a/vagrant/bootstrap-user.sh
+++ b/vagrant/bootstrap-user.sh
@@ -12,7 +12,7 @@ python3 -m pip install --user cryptography pyasn1 pyyaml jinja2 cbor
 # TrustedFirmware-M and dependencies
 mkdir tfm
 cd ~/tfm
-git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git
+git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git -b TF-Mv1.1
 git clone https://github.com/ARMmbed/mbed-crypto.git -b mbedcrypto-3.0.1
 git clone https://git.trustedfirmware.org/TF-M/tf-m-tests.git
 git clone https://github.com/JuulLabs-OSS/mcuboot.git -b v1.6.0


### PR DESCRIPTION
We are supporting `TF-M v1.1`, due to recent changes in the build
system of TF-M repository, the instructions mentioned in the
vagrant/README.md will not work.

Therefore clone specific tag which supports a working version.