### PR TITLE
Switch to using `mbed-tfm-1.1` for tf-m-tests

### DIFF
--- a/psa_builder.py
+++ b/psa_builder.py
@@ -47,8 +47,8 @@ dependencies = {
         ],
         "mcuboot": ["https://github.com/JuulLabs-OSS/mcuboot.git", "v1.6.0"],
         "tf-m-tests": [
-            "https://git.trustedfirmware.org/TF-M/tf-m-tests.git",
-            "master",
+            "https://github.com/ARMmbed/tf-m-tests.git",
+            "mbed-tfm-1.1",
         ],
     },
     "psa-api-compliance": {


### PR DESCRIPTION
Use a specific version of tf-m-tests repository to avoid confusion
on TF-M v1.1 + Mbed OS integration regression tests support.