### PR TITLE
Update support for regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ matrix:
       script:
         # Build TF-M and all tests
         - python3 build_tfm.py -t GNUARM -m ${TARGET_NAME}
+        - python3 build_tfm.py -t GNUARM -m ${TARGET_NAME} -c ConfigRegressionIPC.cmake
+        - mbed compile -t GCC_ARM -m ${TARGET_NAME}
         - ccache -s
 
     # ARM_MUSCA_B1

--- a/test/logs/ARM_MUSCA_B1/REGRESSION.log
+++ b/test/logs/ARM_MUSCA_B1/REGRESSION.log
@@ -2,6 +2,7 @@ Non-secure test suites summary
 Test suite 'PSA protected storage NS interface tests \(TFM_PS_TEST_1XXX\)' has .* PASSED
 Test suite 'PSA internal trusted storage NS interface tests \(TFM_ITS_TEST_1XXX\)' has .* PASSED
 Test suite 'Crypto non-secure interface test \(TFM_CRYPTO_TEST_6XXX\)' has .* PASSED
+Test suite 'Platform Service Non-Secure interface tests\(TFM_PLATFORM_TEST_2XXX\)' has .* PASSED
 Test suite 'Initial Attestation Service non-secure interface tests\(TFM_ATTEST_TEST_2XXX\)' has .* PASSED
 Test suite 'QCBOR regression test\(TFM_QCBOR_TEST_7XXX\)' has .* PASSED
 Test suite 'T_COSE regression test\(TFM_T_COSE_TEST_8XXX\)' has .* PASSED

--- a/test/logs/ARM_MUSCA_S1/REGRESSION.log
+++ b/test/logs/ARM_MUSCA_S1/REGRESSION.log
@@ -2,6 +2,7 @@ Non-secure test suites summary
 Test suite 'PSA protected storage NS interface tests \(TFM_PS_TEST_1XXX\)' has .* PASSED
 Test suite 'PSA internal trusted storage NS interface tests \(TFM_ITS_TEST_1XXX\)' has .* PASSED
 Test suite 'Crypto non-secure interface test \(TFM_CRYPTO_TEST_6XXX\)' has .* PASSED
+Test suite 'Platform Service Non-Secure interface tests\(TFM_PLATFORM_TEST_2XXX\)' has .* PASSED
 Test suite 'Initial Attestation Service non-secure interface tests\(TFM_ATTEST_TEST_2XXX\)' has .* PASSED
 Test suite 'QCBOR regression test\(TFM_QCBOR_TEST_7XXX\)' has .* PASSED
 Test suite 'T_COSE regression test\(TFM_T_COSE_TEST_8XXX\)' has .* PASSED

--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -181,6 +181,72 @@
                 "src": "../../tf-m-tests/test/framework/test_framework_integ_test.h",
                 "dst": "test/inc"
             }
+        ],
+        "regression_libs": [
+            {
+                "src": "app/libtfm_ns_integration_test.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "interface/libpsa_api_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "lib/ext/qcbor/libtfm_qcbor.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "lib/ext/qcbor/libtfm_qcbor_test.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "lib/ext/t_cose/libtfm_t_cose.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "lib/ext/t_cose/libtfm_t_cose_test.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "platform/libplatform_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/attestation/libtfm_test_suite_attestation_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/core/libtfm_test_suite_core_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/crypto/libtfm_test_suite_crypto_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/ipc/libtfm_test_suite_ipc_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/its/libtfm_test_suite_its_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/platform/libtfm_test_suite_platform_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/ps/libtfm_test_suite_ps_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/qcbor/libtfm_test_suite_qcbor_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/t_cose/libtfm_test_suite_t_cose_ns.a",
+                "dst": "test/lib"
+            }
         ]
     }
 }


### PR DESCRIPTION
Preceding PRs: https://github.com/ARMmbed/trusted-firmware-m/pull/13 and https://github.com/ARMmbed/trusted-firmware-m/pull/12

This PR:
* Updates `tfm_ns_import.yaml` and `build_tfm.py` to copy libraries required by regression tests
* Updates regression tests log for ARM_MUSCA_B1 and ARM_MUSCA_S1