### PR TITLE
Enable sync for Greentea test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ After building the [TF-M regression](#Building-the-TF-M-Regression-Test) or
 [PSA compliance tests](#Building-the-PSA-Compliance-Test) for the target, it should be
 followed by building a Mbed OS application. This will execute the test suites previously built.
 
-Configure appropriate test in the `config` section of `mbed_app.json`.
+Configure an appropriate test in the `config` section of `mbed_app.json`. If you want to
+flash and run tests manually, please set `wait-for-sync` to 0 so that tests start without
+waiting.
 
 ```
 mbed compile -m ARM_MUSCA_B1 -t GCC_ARM
@@ -108,6 +110,8 @@ python3 test_psa_target.py -t GNUARM -m ARM_MUSCA_B1
 environment because it does not have access to the USB of the host machine to
 connect the target and therefore cannot run the tests, except it can only be
 used to build all the tests by `-b` option.
+If you want to flash and run tests manually instead of automating them with Greentea,
+you need to pass `--no_sync` so that tests start without waiting.
 
 To display help on supported options and targets:
 

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 
 #include "mbed.h"
 #include "unity.h"
+#include "greentea-client/test_env.h"
 
 #if MBED_CONF_APP_REGRESSION_TEST
 
@@ -20,6 +21,11 @@ extern "C" void TIMER1_Handler(void);
 
 int main(void)
 {
+#if MBED_CONF_APP_WAIT_FOR_SYNC
+    tfm_log_printf("Waiting for Greentea host\n");
+    GREENTEA_SETUP(60, "default_auto");
+#endif
+
     // Use TF-M regression test TIMER1 IRQ handler for the TIMER1 IRQ. The TF-M
     // IRQ test requires its own handler to be installed.
     NVIC_SetVector(TFM_TIMER1_IRQ, (uint32_t)TIMER1_Handler);
@@ -49,6 +55,11 @@ extern "C" int tfm_log_printf(const char *fmt, ...)
 
 int main(void)
 {
+#if MBED_CONF_APP_WAIT_FOR_SYNC
+    tfm_log_printf("Waiting for Greentea host\n");
+    GREENTEA_SETUP(60, "default_auto");
+#endif
+
     // Disable deep sleep
     sleep_manager_lock_deep_sleep();
 

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "regression-test": 1,
-        "psa-compliance-test": 0
+        "psa-compliance-test": 0,
+        "wait-for-sync": 1
     },
     "target_overrides": {
         "*": {


### PR DESCRIPTION
In a standard Greentea test setup, the host sends a sync signal to the target to start the test. This helps to avoid synchronisation issues, e.g. test already running before the host is ready.

To enable this, set "wait-for-sync" to 1 in `mbed_app.json`, or pass `--sync` to `test_psa_target.py`.

Note: Images built this way will NOT start tests on its own - they need to be driven by the Greentea host tools.

Log:
```
[1612528946.71][CONN][RXD] Booting TFM v1.1                                                              
[1612528946.71][CONN][RXD] Waiting for Greentea host      
[1612528946.71][CONN][RXD] mbedmbedmbedmbedmbedmbedmbedmbed                     
[1612528946.72][CONN][RXD] Starting TF-M regression tests                                                
[1612528946.72][CONN][INF] found SYNC in stream: {{__sync;4c998dcc-79ef-4f03-a9ae-450f65db60da}} it is #0 sent, queued...
```