### PR TITLE
Rename configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run `mbed deploy` to obtain Mbed OS for this application.
 
 We are building for the ARM Musca B1 (`ARM_MUSCA_B1`) in our example
 below, but other targets can be built for by changing the `-m` option.
-This builds the `ConfigCoreIPC.cmake` config by default.
+This builds the `CoreIPC` config by default.
 
 ```
 python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM
@@ -46,7 +46,7 @@ python3 build_tfm.py -h
 Use the `-c` option to specify the config to override the default.
 
 ```
-python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM -c ConfigRegressionIPC.cmake
+python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM -c RegressionIPC
 ```
 
 ## Building the PSA Compliance Test
@@ -60,7 +60,7 @@ Run `build_tfm.py` with the PSA API config to build for a target.
 Different suites can be built using the `-s` option.
 
 ```
-python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM -c ConfigPsaApiTestIPC.cmake -s CRYPTO
+python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM -c PsaApiTestIPC -s CRYPTO
 ```
 
 **Note**: Make sure the TF-M Regression Test suite has **PASSED** on the board before

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -56,10 +56,10 @@ dependencies = {
 
 TC_DICT = {"ARMCLANG": "ARMC6", "GNUARM": "GCC_ARM"}
 
-SUPPORTED_TFM_PSA_CONFIGS = ["ConfigPsaApiTestIPC.cmake"]
+SUPPORTED_TFM_PSA_CONFIGS = ["PsaApiTestIPC"]
 SUPPORTED_TFM_CONFIGS = [
-    "ConfigCoreIPC.cmake",  # Default config
-    "ConfigRegressionIPC.cmake",
+    "CoreIPC",  # Default config
+    "RegressionIPC",
 ] + SUPPORTED_TFM_PSA_CONFIGS
 
 PSA_SUITE_CHOICES = [

--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -200,7 +200,7 @@ def _run_regression_test(args):
     logging.info("Build TF-M regression tests for %s", args.mcu)
 
     _set_json_param(1, 0)
-    _build_tfm(args, "ConfigRegressionIPC.cmake")
+    _build_tfm(args, "RegressionIPC")
     _build_mbed_os(args)
 
     if not args.build:
@@ -228,7 +228,7 @@ def _run_compliance_test(args):
 
         logging.info("Build PSA Compliance - %s suite for %s", suite, args.mcu)
 
-        _build_tfm(args, "ConfigPsaApiTestIPC.cmake", suite)
+        _build_tfm(args, "PsaApiTestIPC", suite)
         _build_mbed_os(args)
 
         if not args.build:


### PR DESCRIPTION
The IPC configurations `Config<...>IPC.cmake` are legacies of TF-M v1.1, and those .cmake files do not exist for TF-M v1.2
anymore. So this commit simplifies the configuration names to remove legacy references.