### PR TITLE
Exclude the Crypto suite from the Greentea test spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,25 @@ mbed compile -m ARM_MUSCA_B1 -t GCC_ARM
 This will build and execute TF-M regression and PSA compliance tests with
 Mbed OS application. Make sure the device is connected to your local machine.
 
-
 ```
 python3 test_psa_target.py -t GNUARM -m ARM_MUSCA_B1
 ```
 
-**Note**: This script cannot be executed in the vagrant
+**Notes**:
+* This script cannot be executed in the vagrant
 environment because it does not have access to the USB of the host machine to
 connect the target and therefore cannot run the tests, except it can only be
 used to build all the tests by `-b` option.
-If you want to flash and run tests manually instead of automating them with Greentea,
+* If you want to flash and run tests manually instead of automating them with Greentea,
 you need to pass `--no-sync` so that tests start without waiting.
+* The PSA Crypto test suite is currently excluded from the automated run of all
+tests, because some Crypto tests are known to crash and reboot the target. This
+causes the Greentea test framework to lose synchronization, and messes up the memory
+and prevents subsequent suites from running.
+You can flash and run the Crypto suite standalone. Make sure to either pass `--no-sync`
+to `test_psa_target.py` when building tests, or build the Crypto suite manually with
+`wait-for-sync` set to 0 in `mbed_app.json`. And power cycle the target before and after
+the run to clear the memory.
 
 To display help on supported options and targets:
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ environment because it does not have access to the USB of the host machine to
 connect the target and therefore cannot run the tests, except it can only be
 used to build all the tests by `-b` option.
 If you want to flash and run tests manually instead of automating them with Greentea,
-you need to pass `--no_sync` so that tests start without waiting.
+you need to pass `--no-sync` so that tests start without waiting.
 
 To display help on supported options and targets:
 

--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@ int main(void)
 {
 #if MBED_CONF_APP_WAIT_FOR_SYNC
     tfm_log_printf("Waiting for Greentea host\n");
-    GREENTEA_SETUP(60, "default_auto");
+    GREENTEA_SETUP(600, "default_auto");
 #endif
 
     // Use TF-M regression test TIMER1 IRQ handler for the TIMER1 IRQ. The TF-M
@@ -57,7 +57,7 @@ int main(void)
 {
 #if MBED_CONF_APP_WAIT_FOR_SYNC
     tfm_log_printf("Waiting for Greentea host\n");
-    GREENTEA_SETUP(60, "default_auto");
+    GREENTEA_SETUP(600, "default_auto");
 #endif
 
     // Disable deep sleep

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -121,6 +121,14 @@ def are_dependencies_installed():
         command = ["srec_cat", "--version"]
         return run_cmd_and_return(command)
 
+    def _is_mbedgt_installed():
+        """
+        Check if mbedgt is installed
+        :return: errorcode
+        """
+        command = ["mbedgt", "--version"]
+        return run_cmd_and_return(command)
+
     if _is_git_installed() != 0:
         logging.error('"git" is not installed. Exiting...')
         return -1
@@ -132,6 +140,9 @@ def are_dependencies_installed():
         return -1
     elif _is_srec_installed() != 0:
         logging.error('"srec_cat" is not installed. Exiting...')
+        return -1
+    elif _is_mbedgt_installed() != 0:
+        logging.error('"mbedgt" is not installed. Exiting...')
         return -1
     else:
         return 0

--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -202,6 +202,12 @@ def _execute_test():
     """
     Execute greentea runs test as specified in test_spec.json
     """
+    if not os.path.isfile("test_spec.json"):
+        logging.critical(
+            "test_spec.json is not found, please build the tests first"
+        )
+        sys.exit(1)
+
     cmd = ["mbedgt", "--polling-timeout", "300", "-V"]
 
     run_cmd_output_realtime(cmd, os.getcwd())
@@ -348,7 +354,14 @@ def _get_parser():
     )
 
     parser.add_argument(
-        "--no_sync",
+        "-r",
+        "--run",
+        help="Run on the target only",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--no-sync",
         help="Tests start without waiting for sync from Greentea host",
         action="store_true",
     )
@@ -366,16 +379,25 @@ def _main():
 
     logging.info("Target - %s", args.mcu)
 
-    test_spec = _init_test_spec(args)
-    _build_regression_test(args, test_spec)
-    _build_compliance_test(args, test_spec)
+    build = args.build
+    run = args.run
 
-    with open("test_spec.json", "w") as f:
-        f.write(json.dumps(test_spec, indent=2))
+    # Default to build and run
+    if not args.build and not args.run:
+        build = True
+        run = True
 
-    if args.build:
+    if build:
+        test_spec = _init_test_spec(args)
+        _build_regression_test(args, test_spec)
+        _build_compliance_test(args, test_spec)
+
+        with open("test_spec.json", "w") as f:
+            f.write(json.dumps(test_spec, indent=2))
+
         logging.info("Target built succesfully - %s", args.mcu)
-    else:
+
+    if run:
         _execute_test()
 
 

--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -208,7 +208,7 @@ def _execute_test():
         )
         sys.exit(1)
 
-    cmd = ["mbedgt", "--polling-timeout", "300", "-V"]
+    cmd = ["mbedgt", "--polling-timeout", "600", "-V"]
 
     run_cmd_output_realtime(cmd, os.getcwd())
 

--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -321,9 +321,16 @@ def _build_compliance_test(args, test_spec):
         _build_mbed_os(args)
         binary_name = _erase_flash_storage(args, suite)
 
-        test_spec["builds"][test_group]["tests"][suite] = _get_test_spec(
-            args, suite, binary_name
-        )
+        # Issue: https://github.com/ARM-software/psa-arch-tests/issues/252
+        # The Crypto suite is known to crash and reset the target during runs.
+        # This causes the Greentea test framework to lose synchronization, and
+        # messes up the memory and prevents subsequent suites from running.
+        # The PSA tests currently provide no option to skip known failures.
+        # Users can still run the Crypto suite manually without automation.
+        if suite != "CRYPTO":
+            test_spec["builds"][test_group]["tests"][suite] = _get_test_spec(
+                args, suite, binary_name
+            )
 
 
 def _get_parser():


### PR DESCRIPTION
Issue: ARM-software/psa-arch-tests#252
Some test cases of the Crypto suite are known to crash during runs. This causes the Greentea test framework to lose synchronization, and messes up the memory and prevents subsequent suites from running There's currently no option in psa-arch-tests to skip known failures. So we exclude the Crypto suite from Greentea runs. Users can still run the Crypto suite manually without automation.

Additionally, this PR adds an option `-r/--run-only` to `test_psa_target.py`. It also improves code readability as @saheerb raised in https://github.com/ARMmbed/mbed-os-tf-m-regression-tests/pull/74#discussion_r572919443.

Crypto Test failure - https://developer.trustedfirmware.org/T865