### PR TITLE
Update Vagrant scripts and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,20 @@ with the Mbed OS.
 
 ### Development environment
 
-Please refer to `vagrant/bootstrap.sh` and `vagrant/bootstrap-user.sh` for
-details on how to set up a development environment. These scripts can be run
-locally on Linux, or you may use Vagrant to create a VM suitable for
-development (see `vagrant/README.md` for instructions).
+We have provided a ready-to-use Vagrant virtual machine for building
+TF-M tests, see [`vagrant/README.md`](vagrant/README.md) for instructions.
+
+If you prefer to build and run the tests directly on your host machine,
+take a look at `vagrant/bootstrap.sh` and `vagrant/bootstrap-user.sh` for
+details on how to set up a development environment.
 
 ### Mbed initialization
 
-Run `mbed deploy` to obtain Mbed OS for this application.
+Run `mbed deploy` to obtain Mbed OS for this application. Then run
+```
+python3 -m pip install -r mbed-os/requirements.txt
+```
+to install dependencies for the Mbed tools.
 
 ## Building TF-M
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -4,76 +4,43 @@ This is a fairly minimal Vagrantfile and associated bootstrap scripts for
 setting up a GCC-based build environment for
 [TrustedFirmware-M](https://www.trustedfirmware.org).
 
-Note that the vagrant virtual machine will contain an independent copy of TF-M
-and the mbed-os-tf-m-regression-tests.
-
-Note that by default vagrant shares `/vagrant` in the virtual machine with the
+Note that by default Vagrant shares `/vagrant` in the virtual machine with the
 host. You can use this directory to copy binaries from inside the vagrant
 machine out to the host for e.g. programming via USB.
 
 # Howto
 
-### TF-M + Mbed OS Regression Tests
+## Setting up the Vagrant virtual machine
 
-The following quickstart instructions will build you the TF-M regression tests
-for MUSCA_B1 on Mbed OS.
+First, you need to install Vagrant by following https://www.vagrantup.com/docs/installation.
 
+To prepare, start and log on to the virtual machine:
 ```
 $ cd vagrant
 $ vagrant up
 $ vagrant ssh
-$ cd mbed-os-tf-m-regression-tests
-$ mbed deploy
-$ python3 build_tfm.py -m ARM_MUSCA_B1 -t GNUARM -c ConfigRegressionIPC.cmake
+```
+The initial fetching and setup will take some time, but this will only happen once when you
+start the virtual machine for the first time.
+
+Now you can follow [the main README](../README.md) for mbed-os-tf-m-regression-tests to fetch and
+build the TF-M regression tests and PSA compliance tests for supported targets in the virtual
+machine.
+
+## Exiting and shutting down the virtual machine
+
+To log out of the virtual machine, press <kbd>Ctrl</kbd> + <kbd>D</kbd>. This takes your terminal's
+prompt back to your host machine, but the virtual machine is still running in the background.
+
+To shut down the virtual machine:
+```
+vagrant halt
 ```
 
-### TF-M Standalone Regression Tests
+## Removing the virtual machine
 
-These quickstart instructions will build you the TF-M regression tests for
-MUSCA_B1 standalone (without Mbed OS).
-
+To completely remove the virtual machine:
 ```
-$ cd vagrant
-$ vagrant up
-$ vagrant ssh
-$ cd tfm/trusted-firmware-m
-$ mkdir cmake_build
-$ cd cmake_build
-$ cmake -G"Unix Makefiles" -DPROJ_CONFIG=`readlink -f ../configs/ConfigRegressionIPC.cmake` -DTARGET_PLATFORM=MUSCA_B1 -DCOMPILER=GNUARM -DCMAKE_BUILD_TYPE=Release ../
-$ cmake --build .
+vagrant destroy
 ```
-
-After the build completes, you should see output like the following:
-```
---- snip 8< ---
-[ 91%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/target/musca_b1/Native_Driver/gpio_cmsdk_drv.o
-[ 92%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/common/boot_hal.o
-[ 92%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/target/musca_b1/boot_hal.o
-[ 92%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/common/template/tfm_initial_attestation_key_material.o
-[ 93%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/common/template/tfm_rotpk.o
-[ 93%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/target/musca_b1/dummy_crypto_keys.o
-[ 94%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/common/template/nv_counters.o
-[ 94%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/target/musca_b1/CMSIS_Driver/Driver_USART.o
-[ 95%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/target/musca_b1/CMSIS_Driver/Driver_QSPI_Flash.o
-[ 95%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/__/platform/ext/target/musca_b1/CMSIS_Driver/Driver_GFC100_EFlash.o
-[ 95%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/bl2_main.o
-[ 96%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/flash_map_extended.o
-[ 96%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/flash_map_legacy.o
-[ 97%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/keys.o
-[ 97%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/src/flash_map.o
-[ 97%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/bootutil/src/loader.o
-[ 98%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/bootutil/src/bootutil_misc.o
-[ 98%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/bootutil/src/image_validate.o
-[ 99%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/bootutil/src/image_rsa.o
-[ 99%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/bootutil/src/tlv.o
-[ 99%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/src/boot_record.o
-[100%] Building C object bl2/ext/mcuboot/CMakeFiles/mcuboot.dir/__/__/src/security_cnt.o
-[100%] Linking C executable mcuboot.axf
-Memory region         Used Size  Region Size  %age Used
-           FLASH:       19828 B       128 KB     15.13%
-        CODE_RAM:        1164 B       512 KB      0.22%
-             RAM:       22560 B       512 KB      4.30%
-[100%] Built target mcuboot
-```
-
-See [TF-M's documentation](https://ci.trustedfirmware.org/job/tf-m-build-test-nightly/lastSuccessfulBuild/artifact/build-docs/tf-m_documents/install/doc/user_guide/html/index.html) for further details.
+This removes any files in the virtual machine too.

--- a/vagrant/bootstrap-user.sh
+++ b/vagrant/bootstrap-user.sh
@@ -7,29 +7,4 @@ mkdir -p ~/.local
 mv gcc-arm-none-eabi-9-2019-q4-major/* ~/.local/
 
 # Python environment
-python3 -m pip install --user cryptography pyasn1 pyyaml jinja2 cbor
-
-# TrustedFirmware-M and dependencies
-mkdir tfm
-cd ~/tfm
-git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git -b TF-Mv1.1
-git clone https://github.com/ARMmbed/mbed-crypto.git -b mbedcrypto-3.0.1
-git clone https://git.trustedfirmware.org/TF-M/tf-m-tests.git
-git clone https://github.com/JuulLabs-OSS/mcuboot.git -b v1.6.0
-git clone https://github.com/ARM-software/CMSIS_5.git -b 5.5.0
-cd ~/tfm/CMSIS_5
-wget -q https://github.com/ARM-software/CMSIS_5/releases/download/5.5.0/ARM.CMSIS.5.5.0.pack
-unzip -o ARM.CMSIS.5.5.0.pack
-cd ~/tfm/trusted-firmware-m
-git remote add ARMmbed https://github.com/ARMmbed/trusted-firmware-m.git
-git fetch --all
-
-# Regression tests
-cd
-git clone https://github.com/ARMmbed/mbed-os-tf-m-regression-tests.git
-cd ~/mbed-os-tf-m-regression-tests
-git clone https://github.com/ARMmbed/mbed-os.git
-
-# Mbed tools
-python3 -m pip install mbed-cli
-python3 -m pip install -r mbed-os/requirements.txt
+python3 -m pip install --user cryptography pyasn1 pyyaml jinja2 cbor mbed-cli

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -10,3 +10,4 @@ apt-get install -y \
 	python3-pip \
 	srecord \
 	unzip \
+	ninja-build \

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 apt-get update
+apt-get full-upgrade -y
 apt-get install -y \
 	build-essential \
 	cmake \


### PR DESCRIPTION
To minimise the maintenance effort, we've decided that the Vagrant virtual machine should only provide an environment. This PR
* removes the fetching of TF-M related repositories from the scripts
* removes instructions to build the vanilla TF-M
* adds more info on how to use the virtual machine
* adds `ninja-build` to the script, as we use Ninja to speed up TF-M v1.2 build

Tested on Musca S1.