### PR TITLE
Add new functionality to `build_tfm.py` 

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,1 +1,1 @@
-aaca620d33f5
+f17ce5d3dc6a

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -535,19 +535,21 @@ def _build_target(tgt, cmake_build_dir, args):
 
     _run_cmake_build(cmake_build_dir, args, tgt, args.config)
 
-    source = join(cmake_build_dir, "install", "outputs", tgt[1].upper())
-    _copy_binaries(source, tgt[3], tgt[2], tgt[0])
-    tgt_list.append((tgt[0], tgt[2]))
+    if not args.skip_copy:
+        source = join(cmake_build_dir, "install", "outputs", tgt[1].upper())
+        _copy_binaries(source, tgt[3], tgt[2], tgt[0])
+        tgt_list.append((tgt[0], tgt[2]))
 
     if args.commit:
         _commit_changes(tgt[3], tgt_list)
 
-    if args.config == SUPPORTED_TFM_CONFIGS[1]:
-        _copy_library(cmake_build_dir, tgt[2])
-    elif args.config in SUPPORTED_TFM_PSA_CONFIGS:
-        _copy_psa_libs(cmake_build_dir, ROOT, args)
+    if not args.skip_copy:
+        if args.config == SUPPORTED_TFM_CONFIGS[1]:
+            _copy_library(cmake_build_dir, tgt[2])
+        elif args.config in SUPPORTED_TFM_PSA_CONFIGS:
+            _copy_psa_libs(cmake_build_dir, ROOT, args)
 
-    _copy_tfm_ns_files(cmake_build_dir, tgt[0])
+        _copy_tfm_ns_files(cmake_build_dir, tgt[0])
 
 
 def _build_tfm(args):
@@ -670,6 +672,13 @@ def _get_parser():
     parser.add_argument(
         "--skip-clone",
         help="Skip cloning/checkout of TF-M dependencies",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--skip-copy",
+        help="Skip copying TF-M dependencies to Mbed OS",
         action="store_true",
         default=False,
     )

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -659,6 +659,13 @@ def _get_parser():
         default=None,
     )
 
+    parser.add_argument(
+        "--clean",
+        help="Clean the cloned dependencies",
+        action="store_true",
+        default=False,
+    )
+
     return parser
 
 
@@ -703,6 +710,11 @@ def _main():
                 )
             )
             return
+
+    if args.clean:
+        if isdir(TF_M_BUILD_DIR):
+            logging.info("Removing folder %s" % TF_M_BUILD_DIR)
+            shutil.rmtree(TF_M_BUILD_DIR)
 
     if not isdir(TF_M_BUILD_DIR):
         os.mkdir(TF_M_BUILD_DIR)

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -556,7 +556,8 @@ def _build_tfm(args):
     :param args: Command-line arguments
     """
 
-    _clone_tfm_repo(args.commit)
+    if not args.skip_clone:
+        _clone_tfm_repo(args.commit)
 
     cmake_build_dir = join(TF_M_BUILD_DIR, "trusted-firmware-m", "cmake_build")
     if isdir(cmake_build_dir):
@@ -666,6 +667,13 @@ def _get_parser():
         default=False,
     )
 
+    parser.add_argument(
+        "--skip-clone",
+        help="Skip cloning/checkout of TF-M dependencies",
+        action="store_true",
+        default=False,
+    )
+
     return parser
 
 
@@ -712,6 +720,12 @@ def _main():
             return
 
     if args.clean:
+        if args.skip_clone:
+            args.skip_clone = False
+            logging.info(
+                "Cannot force to skip cloning/checkout when clean option is specified"
+            )
+
         if isdir(TF_M_BUILD_DIR):
             logging.info("Removing folder %s" % TF_M_BUILD_DIR)
             shutil.rmtree(TF_M_BUILD_DIR)

--- a/ci_scripts/build_external_tfm.py
+++ b/ci_scripts/build_external_tfm.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2021 ARM Limited. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from os.path import join, isdir
+import argparse
+import sys
+import signal
+import logging
+import shutil
+
+sys.path.append("../")
+from psa_builder import *
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[Build-external-TF-M] %(asctime)s: %(message)s.",
+    datefmt="%H:%M:%S",
+)
+
+
+def _copy_tfm_binaries(args, suite):
+    """
+    Copy TF-M binaries from source to destination
+    :param args: Command-line arguments
+    :param suite: Test suite for PSA compliance
+    """
+
+    src_folder = join(
+        TF_M_BUILD_DIR, "trusted-firmware-m", "cmake_build", "bin"
+    )
+    dst_folder = join(
+        ROOT, "BUILD", args.mcu, TC_DICT[args.toolchain], "TFM", suite
+    )
+
+    logging.info("Copying folder: " + src_folder + " - to - " + dst_folder)
+    if not isdir(dst_folder):
+        os.makedirs(dst_folder)
+    for f in os.listdir(src_folder):
+        if os.path.isfile(join(src_folder, f)):
+            shutil.copy2(join(src_folder, f), join(dst_folder, f))
+
+
+def _build_tfm(args, config, suite):
+    """
+    Build TF-M regression test
+    :param args: Command-line arguments
+    :param config: Config type
+    :param suite: Test suite for PSA compliance
+    """
+    cmd = [
+        "python3",
+        "build_tfm.py",
+        "-m",
+        args.mcu,
+        "-t",
+        args.toolchain,
+        "-c",
+        config,
+        "--skip-clone",
+        "--skip-copy",
+    ]
+
+    if config in SUPPORTED_TFM_PSA_CONFIGS:
+        cmd.append("-s")
+        cmd.append(suite)
+
+    retcode = run_cmd_output_realtime(cmd, ROOT)
+    if retcode:
+        logging.critical("Unable to build TF-M for target - %s", args.mcu)
+        sys.exit(1)
+
+    _copy_tfm_binaries(args, suite)
+
+
+def _build_regression_test(args):
+    """
+    Build TF-M regression test for the target
+    :param args: Command-line arguments
+    """
+    logging.info("Build TF-M regression tests for %s", args.mcu)
+
+    _build_tfm(args, "RegressionIPC", "REGRESSION")
+
+
+def _build_compliance_test(args):
+    """
+    Build PSA Compliance test for the target
+    :param args: Command-line arguments
+    """
+
+    for suite in PSA_SUITE_CHOICES:
+
+        # Issue : https://github.com/ARMmbed/mbed-os-tf-m-regression-tests/issues/49
+        # There is no support for this target to run Firmware Framework tests
+        if suite == "IPC" and args.mcu == "ARM_MUSCA_S1":
+            logging.info(
+                "%s config is not supported for %s target" % (suite, args.mcu)
+            )
+            continue
+
+        logging.info("Build PSA Compliance - %s suite for %s", suite, args.mcu)
+
+        _build_tfm(args, "PsaApiTestIPC", suite)
+
+
+def _get_parser():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "-m",
+        "--mcu",
+        help="Build for the given MCU",
+        choices=["ARM_MUSCA_S1"],
+        default=None,
+    )
+
+    parser.add_argument(
+        "-t",
+        "--toolchain",
+        help="Build for the given toolchain",
+        default=None,
+        choices=["ARMCLANG", "GNUARM"],
+    )
+
+    return parser
+
+
+def _main():
+    """
+    Build and run Regression, PSA compliance for suported targets
+    """
+    signal.signal(signal.SIGINT, exit_gracefully)
+    parser = _get_parser()
+    args = parser.parse_args()
+
+    logging.info("Target - %s", args.mcu)
+
+    _build_regression_test(args)
+    _build_compliance_test(args)
+
+    logging.info("Target built succesfully - %s", args.mcu)
+
+
+if __name__ == "__main__":
+    if are_dependencies_installed() != 0:
+        sys.exit(1)
+    else:
+        _main()

--- a/ci_scripts/check_rebase.py
+++ b/ci_scripts/check_rebase.py
@@ -27,7 +27,7 @@ from psa_builder import *
 
 logging.basicConfig(
     level=logging.INFO,
-    format="[Rebase-Check] %(asctime)s: %(message)s.",
+    format="[Check-Rebase] %(asctime)s: %(message)s.",
     datefmt="%H:%M:%S",
 )
 
@@ -93,7 +93,7 @@ def _perform_rebase(repo, remote_1, remote_2, dir):
     :param dir: Directory to perform operation
     """
 
-    gitbranch_1 = dependencies[remote_1].get(repo)[1] + "-rebase"
+    gitbranch_1 = dependencies[remote_1].get(repo)[1] + "-trial"
     gitbranch_2 = dependencies[remote_2].get(repo)[1]
 
     check_and_clone_repo(repo, remote_1, TF_M_BUILD_DIR)
@@ -122,14 +122,20 @@ def _setup_and_rebase_tfm_repositories():
     Setup TF-M git repo and its dependencies while performing a rebase
     """
     check_and_clone_repo("trusted-firmware-m", "upstream-tfm", TF_M_BUILD_DIR)
-    _add_remote_repo("trusted-firmware-m", "mbed-tfm", TF_M_BUILD_DIR)
+    _add_remote_repo("trusted-firmware-m", "mbed-tfm-rebase", TF_M_BUILD_DIR)
     _perform_rebase(
-        "trusted-firmware-m", "mbed-tfm", "upstream-tfm", TF_M_BUILD_DIR
+        "trusted-firmware-m", "mbed-tfm-rebase", "upstream-tfm", TF_M_BUILD_DIR
     )
 
     check_and_clone_repo("tf-m-tests", "upstream-tfm", TF_M_BUILD_DIR)
-    _add_remote_repo("tf-m-tests", "mbed-tfm", TF_M_BUILD_DIR)
-    _perform_rebase("tf-m-tests", "mbed-tfm", "upstream-tfm", TF_M_BUILD_DIR)
+    _add_remote_repo("tf-m-tests", "mbed-tfm-rebase", TF_M_BUILD_DIR)
+    _perform_rebase(
+        "tf-m-tests", "mbed-tfm-rebase", "upstream-tfm", TF_M_BUILD_DIR
+    )
+
+    check_and_clone_repo(
+        "psa-arch-tests", "psa-api-compliance", TF_M_BUILD_DIR
+    )
 
 
 def _main():

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -45,6 +45,16 @@ dependencies = {
             "mbed-tfm-1.2",
         ],
     },
+    "mbed-tfm-rebase": {
+        "trusted-firmware-m": [
+            "https://github.com/ARMmbed/trusted-firmware-m.git",
+            "mbed-tfm-rebase-check",
+        ],
+        "tf-m-tests": [
+            "https://github.com/ARMmbed/tf-m-tests.git",
+            "mbed-tfm-rebase-check",
+        ],
+    },
     "upstream-tfm": {
         "trusted-firmware-m": [
             "https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git",

--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -110,6 +110,9 @@ def _build_tfm(args, config, suite=None):
     if args.clean:
         cmd.append("--clean")
 
+    if args.skip_clone:
+        cmd.append("--skip-clone")
+
     retcode = run_cmd_output_realtime(cmd, ROOT)
     if retcode:
         logging.critical("Unable to build TF-M for target - %s", args.mcu)
@@ -359,6 +362,13 @@ def _get_parser():
     parser.add_argument(
         "--clean",
         help="Clean the cloned dependencies",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--skip-clone",
+        help="Skip cloning/checkout of TF-M dependencies",
         action="store_true",
         default=False,
     )

--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -107,6 +107,9 @@ def _build_tfm(args, config, suite=None):
         cmd.append("-s")
         cmd.append(suite)
 
+    if args.clean:
+        cmd.append("--clean")
+
     retcode = run_cmd_output_realtime(cmd, ROOT)
     if retcode:
         logging.critical("Unable to build TF-M for target - %s", args.mcu)
@@ -351,6 +354,13 @@ def _get_parser():
         "--list",
         help="Print supported TF-M secure targets",
         action="store_true",
+    )
+
+    parser.add_argument(
+        "--clean",
+        help="Clean the cloned dependencies",
+        action="store_true",
+        default=False,
     )
 
     return parser


### PR DESCRIPTION
This enables the building of TF-M latest config which was set up by `check_rebase.py`.

 `build_external_tfm.py` builds `ARM_MUSCA_S1` target with the external TF-M + patches required by Mbed OS. It relies on `check_rebase.py` to set up the required dependencies.