### PR TITLE
Fix path in commit message generated by `--commit`

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -171,7 +171,7 @@ def _commit_changes(directory, target_toolchain=None):
                 relpath(directory, mbed_path),
             ]
             run_cmd_and_return(cmd)
-            msg = '--message="Updated directory %s "' % directory
+            msg = '--message="Updated directory %s"' % relpath(directory, mbed_path)
             cmd = ["git", "-C", mbed_path, "commit", msg]
             run_cmd_and_return(cmd)
         else:


### PR DESCRIPTION
The path in a commit message auto-generated by `--commit` should be relative to `mbed-os`.