### PR TITLE
Fix read permission error on host OS

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -560,7 +560,7 @@ def _build_tfm(args):
 
     cmake_build_dir = join(TF_M_BUILD_DIR, "trusted-firmware-m", "cmake_build")
     if isdir(cmake_build_dir):
-        shutil.rmtree(cmake_build_dir)
+        shutil.rmtree(cmake_build_dir, onerror=handle_read_permission_error)
 
     os.mkdir(cmake_build_dir)
 

--- a/ci_scripts/check_rebase.py
+++ b/ci_scripts/check_rebase.py
@@ -141,7 +141,7 @@ def _main():
     logging.info("Using folder %s" % TF_M_BUILD_DIR)
 
     if isdir(TF_M_BUILD_DIR):
-        shutil.rmtree(TF_M_BUILD_DIR)
+        shutil.rmtree(TF_M_BUILD_DIR, onerror=handle_read_permission_error)
 
     os.mkdir(TF_M_BUILD_DIR)
 

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -22,8 +22,7 @@ import sys
 import subprocess
 from os.path import join, dirname, abspath, isdir
 import logging
-import requests
-from zipfile import ZipFile
+import stat
 
 try:
     import yaml
@@ -329,3 +328,13 @@ def get_tfm_regression_targets():
         )
 
         return regression_targets
+
+
+def handle_read_permission_error(func, path, exc_info):
+    """
+    Handle read permission error when deleting a directory
+    It will try to change file permission and call the calling function again.
+    """
+    if not os.access(path, os.W_OK):
+       os.chmod(path, stat.S_IWUSR)
+       func(path)


### PR DESCRIPTION
Fixes #24

The issue on Windows (Host OS) is that it clones dependencies in
read-only mode, which creates an issue when deleting them if
`test_psa_target.py` or `build_tfm.py` is executed.

Therefore handle the permission issue by setting them in read-write
mode.