### PR TITLE
Fix read permission error on host OS

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -737,7 +737,7 @@ def _main():
 
         if isdir(TF_M_BUILD_DIR):
             logging.info("Removing folder %s" % TF_M_BUILD_DIR)
-            shutil.rmtree(TF_M_BUILD_DIR)
+            shutil.rmtree(TF_M_BUILD_DIR, onerror=handle_read_permission_error)
 
     if not isdir(TF_M_BUILD_DIR):
         os.mkdir(TF_M_BUILD_DIR)


### PR DESCRIPTION
Fixes #24

The permission model on Windows (Host OS) creates an issue when
deleting files, if `test_psa_target.py` or `build_tfm.py` is executed.

Therefore handle it by setting them in read-write mode.

This fix was missed when PR #80 was merged after #83

To be squashed with 03fb1c0