### PR TITLE
Fix python formats and enable checks on all branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,11 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches:
+        - '**'
   pull_request:
-    branches: [ master ]
+    branches:
+        - '**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -171,7 +171,9 @@ def _commit_changes(directory, target_toolchain=None):
                 relpath(directory, mbed_path),
             ]
             run_cmd_and_return(cmd)
-            msg = '--message="Updated directory %s"' % relpath(directory, mbed_path)
+            msg = '--message="Updated directory %s"' % relpath(
+                directory, mbed_path
+            )
             cmd = ["git", "-C", mbed_path, "commit", msg]
             run_cmd_and_return(cmd)
         else:

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -346,5 +346,5 @@ def handle_read_permission_error(func, path, exc_info):
     It will try to change file permission and call the calling function again.
     """
     if not os.access(path, os.W_OK):
-       os.chmod(path, stat.S_IWUSR)
-       func(path)
+        os.chmod(path, stat.S_IWUSR)
+        func(path)


### PR DESCRIPTION
Previous, python format checks was not enabled for the branch tf-m-v1.2-integration. This lead to a few format issues.

This PR fixes the formats, and enables the check globally for all branches.