### PR TITLE
Support Mbed CLI 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+# CircleCI 2.1 configuration file
+#
+version: 2.1
+commands:
+  compile:
+    parameters:
+      target:
+        type: string
+    steps:
+      - run: |
+          cd mbed-os-tf-m-regression-tests
+          python3 test_psa_target.py -t GNUARM -m <<parameters.target>> --cli=1 -b
+jobs:
+  build:
+    docker:
+      - image: mbedos/mbed-os-env:stable
+    working_directory: ~
+    steps:
+      - checkout:
+          path: mbed-os-tf-m-regression-tests
+      - run: |
+          apt-get update -y
+          apt-get install -y cmake srecord ninja-build # TF-M dependencies
+          cd mbed-os-tf-m-regression-tests
+          git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git
+      - compile:
+          target: "ARM_MUSCA_S1"
+      - compile:
+          target: "ARM_MUSCA_B1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ dist: focal
 
 addons:
   apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ focal main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
     packages:
       - cmake
       - srecord
@@ -49,11 +52,19 @@ matrix:
       install:
         # Install arm-none-eabi-gcc
         - pushd /home/travis/build && mkdir arm-gcc && cd arm-gcc
-        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D" --output gcc-arm-none-eabi-9-2019-q4-major.tar.bz2
+        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2" --output gcc-arm-none-eabi-9-2019-q4-major.tar.bz2
         - tar xf gcc-arm-none-eabi-9-2019-q4-major.tar.bz2
         - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2019-q4-major/bin"
         - arm-none-eabi-gcc --version
         - popd
+        # Hide Travis-preinstalled CMake
+        # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+        # can't replace it with an apt-supplied version very easily. Additionally, we
+        # can't permit the Travis-preinstalled copy to survive, as the Travis default
+        # path lists the Travis CMake install location ahead of any place where apt
+        # would install CMake to. Instead of apt removing or upgrading to a new CMake
+        # version, we must instead delete the Travis copy of CMake.
+        - sudo rm -rf /usr/local/cmake*
         # Setup ccache
         - ccache -o compiler_check=content
         - ccache -M 1G
@@ -64,11 +75,11 @@ matrix:
         # Fetch mbed-os: We use manual clone, with depth=1 and --single-branch to save time.
         - git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git
         # Install Mbed CLI and dependencies
-        - pip install --upgrade mbed-cli
+        - pip install --upgrade mbed-tools
         - pip install -r mbed-os/requirements.txt
       script:
         # Build TF-M and all tests
-        - python3 test_psa_target.py -t GNUARM -m ${TARGET_NAME} -b
+        - python3 test_psa_target.py -t GNUARM -m ${TARGET_NAME} --cli=2 -b
         - ccache -s
 
     # ARM_MUSCA_B1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,111 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET mbed-os-tf-m-regression-tests)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(${MBED_PATH})
+
+add_executable(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PRIVATE
+        main.cpp
+)
+
+# Note: This is needed because TARGET_** is part of a list instead
+# of a standalone variable, and it controls the path visibility
+# for Mbed CLI 1. Once Mbed CLI 1 is deprecated, we can simplify
+# the path to tfm/targets/${APP_TARGET}/device.
+if(${MBED_TARGET} STREQUAL "ARM_MUSCA_B1")
+    set(TFM_TARGET_INCLUDE tfm/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device)
+elseif(${MBED_TARGET} STREQUAL "ARM_MUSCA_S1")
+    set(TFM_TARGET_INCLUDE tfm/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/device)
+else()
+    message(FATAL_ERROR "Unsupported target ${MBED_TARGET}")
+endif()
+
+target_include_directories(${APP_TARGET}
+    PRIVATE
+        tfm/platform/include
+        ${TFM_TARGET_INCLUDE}
+        test/inc
+)
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        mbed-os
+        mbed-psa
+        mbed-greentea
+)
+
+if ("${MBED_CONFIG_DEFINITIONS}" MATCHES "MBED_CONF_APP_REGRESSION_TEST=1")
+    set(TEST_LIBS
+        # Note: To link successfully the order is important and reflects dependency.
+        # In general: test entry point -> suites -> platform -> utilities.
+        tfm_test_suite_core_ns
+        tfm_test_suite_attestation_ns
+        tfm_test_suite_crypto_ns
+        tfm_test_suite_ipc_ns
+        tfm_test_suite_its_ns
+        tfm_test_suite_platform_ns
+        tfm_test_suite_ps_ns
+        tfm_test_suite_qcbor_ns
+        tfm_test_suite_t_cose_ns
+        tfm_qcbor_test
+        tfm_t_cose_test
+        platform_ns
+        psa_api_ns
+        tfm_ns_integration_test
+        tfm_qcbor
+        tfm_t_cose
+    )
+elseif ("${MBED_CONFIG_DEFINITIONS}" MATCHES "MBED_CONF_APP_PSA_COMPLIANCE_TEST=1")
+    set(TEST_LIBS
+        val_nspe
+        pal_nspe
+        test_combine
+    )
+else()
+    message(FATAL_ERROR "No test enabled in mbed_app.json")
+endif()
+
+# Note: The path transformation is required because `.ar` is not
+# recognized by `-l<name>` of either toolchains. This extension
+# is a legacy of Mbed CLI 1. In the future we should use `.a` for
+# both toolchains, and take advantage of target_link_directories()
+# so each `lib<name>.a` simply becomes `<name>` in target_link_libraries().
+if(${MBED_TOOLCHAIN} STREQUAL "GCC_ARM")
+    set(LIB_SUFFIX ".a")
+elseif(${MBED_TOOLCHAIN} STREQUAL "ARM")
+    set(LIB_SUFFIX ".ar")
+else()
+    message(FATAL_ERROR "Unsupported toolchain ${MBED_TOOLCHAIN}")
+endif()
+
+list(TRANSFORM TEST_LIBS
+    PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/test/lib/TOOLCHAIN_${MBED_TOOLCHAIN}/lib"
+)
+
+list(TRANSFORM TEST_LIBS
+    APPEND "${LIB_SUFFIX}"
+)
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        ${TEST_LIBS}
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/README.md
+++ b/README.md
@@ -6,19 +6,37 @@ for **TF-M v1.2** integrated with the **Mbed OS**.
 
 ## Prerequisites
 
-### Development environment
-
 We have provided a ready-to-use Vagrant virtual machine for building
 TF-M tests, see [`vagrant/README.md`](vagrant/README.md) for instructions.
 
 If you prefer to build and run the tests directly on your host machine,
-ensure you have the following installed:
+please have the following set up.
+
+### TF-M build environment
+
+The following tools are needed for building TF-M:
 * Commands: see [`vagrant/bootstrap.sh`](./vagrant/bootstrap.sh) for Linux,
 or install equivalent packages for your operating system.
 * Python environment: see [`vagrant/bootstrap-user.sh`](./vagrant/bootstrap-user.sh).
 * One of the supported compilers: see "Compiler versions" on
 [Arm Mbed tools](https://os.mbed.com/docs/mbed-os/v6.7/build-tools/index.html).
 Make sure the compiler has been added to the `PATH` of your environment.
+
+### Mbed OS build tools
+
+#### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system,
+and CMake to generate the build environment and manage the build process in a
+compiler-independent manner. If you are working with Mbed OS version prior to 6.5
+then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-tf-m-regression-tests`
+1. Change the current directory to where the project was imported.
+
+#### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
+1. From the command-line, import the example: `mbed import mbed-os-tf-m-regression-tests`
+1. Change the current directory to where the project was imported.
 
 ### Mbed initialization
 
@@ -92,14 +110,28 @@ Configure an appropriate test in the `config` section of `mbed_app.json`. If you
 *flash and run tests manually*, please set `wait-for-sync` to 0 so that tests start without
 waiting.
 
-```
-mbed compile -m ARM_MUSCA_B1 -t GCC_ARM
-```
+Run one of the following commands to build the application
+
+* Mbed CLI 2
+
+    ```
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN>
+    ```
+
+* Mbed CLI 1
+
+    ```bash
+    $ mbed compile -m <TARGET> -t <TOOLCHAIN>
+    ```
+
+The binary is located at:
+* **Mbed CLI 2** - `./cmake_build/<TARGET>/<PROFILE>/<TOOLCHAIN>/mbed-os-tf-m-regression-tests.bin`</br>
+* **Mbed CLI 1** - `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-tf-m-regression-tests.bin`
 
 ## Running the Mbed OS application manually
 
 1. Connect your Mbed Enabled device to the computer over USB.
-1. Copy the binary or hex file to the Mbed device. The binary is located at `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-tf-m-regression-tests.[bin|hex]`.
+1. Copy the binary or hex file to the Mbed device.
 1. Connect to the Mbed Device using a serial client application of your choice.
 1. Press the reset button on the Mbed device to run the program.
 
@@ -110,9 +142,17 @@ mbed compile -m ARM_MUSCA_B1 -t GCC_ARM
 This will build and execute TF-M regression and PSA compliance tests with
 Mbed OS application, using the [Greentea](https://os.mbed.com/docs/mbed-os/v6.7/debug-test/greentea-for-testing-applications.html) test tool. Make sure the device is connected to your local machine.
 
-```
-python3 test_psa_target.py -t GNUARM -m ARM_MUSCA_B1
-```
+* Mbed CLI 2 (default)
+
+    ```
+    python3 test_psa_target.py -t GNUARM -m ARM_MUSCA_B1
+    ```
+
+* Mbed CLI 1
+
+    ```
+    python3 test_psa_target.py -t GNUARM -m ARM_MUSCA_B1 --cli=1
+    ```
 
 **Notes**:
 * The tests cannot be run in the Vagrant

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -25,8 +25,8 @@ import signal
 import shutil
 import logging
 from psa_builder import *
-from tools.toolchains import TOOLCHAIN_CLASSES, TOOLCHAIN_PATHS
-from tools.targets import Target, TARGET_MAP, TARGET_NAMES
+from tools.toolchains import TOOLCHAIN_PATHS
+from tools.targets import TARGET_MAP
 
 logging.basicConfig(
     level=logging.INFO,
@@ -108,11 +108,6 @@ def _get_target_info(target, toolchain=None):
         tc = toolchain
     else:
         tc = TARGET_MAP[target].tfm_default_toolchain
-
-    global TC_DICT
-    if not TOOLCHAIN_CLASSES[TC_DICT.get(tc)].check_executable():
-        msg = "Toolchain %s was not found in PATH" % tc
-        raise Exception(msg)
 
     delivery_dir = join(
         mbed_path, "targets", TARGET_MAP[target].tfm_delivery_dir

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -72,7 +72,7 @@ dependencies = {
     },
 }
 
-TC_DICT = {"ARMCLANG": "ARMC6", "GNUARM": "GCC_ARM"}
+TC_DICT = {"ARMCLANG": "ARM", "GNUARM": "GCC_ARM"}
 
 SUPPORTED_TFM_PSA_CONFIGS = ["PsaApiTestIPC"]
 SUPPORTED_TFM_CONFIGS = [

--- a/vagrant/bootstrap-user.sh
+++ b/vagrant/bootstrap-user.sh
@@ -7,4 +7,4 @@ mkdir -p ~/.local
 mv gcc-arm-none-eabi-9-2019-q4-major/* ~/.local/
 
 # Python environment
-python3 -m pip install --user cryptography pyasn1 pyyaml jinja2 cbor mbed-cli
+python3 -m pip install --user cryptography pyasn1 pyyaml jinja2 cbor mbed-cli mbed-tools

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
+        gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ focal main'
 apt-get update
 apt-get full-upgrade -y
 apt-get install -y \


### PR DESCRIPTION
 This PR
* adds `CMakeLists.txt` to support Mbed CLI 2
* adds an option `--cli=[1|2]` to `test_psa_target.py` to select the Mbed CLI version (defaults to **2** if unspecified)
* updates `README.md` to document the use of Mbed CLI 2
* updates the Travis configurations to use Mbed CLI 2
* adds a CircleCI configuration to test Mbed CLI 1 build - CircleCI is used for consistency with all Mbed OS examples

Note: This PR is able to compile on its own. To be able to run it on an actual target, your check-out of mbed-os needs to have https://github.com/ARMmbed/mbed-os/pull/14361.