### PR TITLE
Use relative paths in Greentea test_spec.json

### DIFF
--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -210,7 +210,7 @@ def _init_test_spec(args):
             test_group: {
                 "platform": target,
                 "toolchain": toolchain,
-                "base_path": os.getcwd(),
+                "base_path": ".",
                 "baud_rate": baud_rate,
                 "tests": {},
             }


### PR DESCRIPTION
Relative paths allow users to build tests in a VM/container and run them in a host without worrying about paths.