### PR TITLE
.travis.yml: use the master branch of mbed-os

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
         - sudo ln -s $(which ccache) bin/arm-none-eabi-g++
         - export PATH="$(pwd)/bin:$PATH"
         # Fetch mbed-os: We use manual clone, with depth=1 and --single-branch to save time.
-        - git clone --depth=1 --single-branch --branch=feature-tf-m-1.2-integration https://github.com/ARMmbed/mbed-os.git
+        - git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git
         # Install Mbed CLI and dependencies
         - pip install --upgrade mbed-cli
         - pip install -r mbed-os/requirements.txt


### PR DESCRIPTION
The TF-M v1.2 integration work has been merged to the master branch of Mbed OS: https://github.com/ARMmbed/mbed-os/pull/14354
Now it's time to switch the branch back in Travis.