### PR TITLE
Use a fixed version of psa-arch-tests

### DIFF
--- a/psa_builder.py
+++ b/psa_builder.py
@@ -67,7 +67,7 @@ dependencies = {
     "psa-api-compliance": {
         "psa-arch-tests": [
             "https://github.com/ARM-software/psa-arch-tests.git",
-            "master",
+            "Before_Crypto_1.0",
         ],
     },
 }


### PR DESCRIPTION
The PSA Crypto API on the master branch of psa-arch-tests has been updated to 1.0.0 but TF-M only support version 1.0-beta-3 of this API, as of the time of this commit. We need to use the tag ["Before_Crypto_1.0"](https://github.com/ARM-software/psa-arch-tests/releases/tag/Before_Crypto_1.0) from the psa-arch-tests repository.