### PR TITLE
CI branch to integrate the latest vanilla TF-M with Mbed OS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,5 +25,6 @@ jobs:
           git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git
       - compile:
           target: "ARM_MUSCA_S1"
-      - compile:
-          target: "ARM_MUSCA_B1"
+      # Temporarily disabled due to target rename in TF-M
+      # - compile:
+      #     target: "ARM_MUSCA_B1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ matrix:
 
     # ARM_MUSCA_B1
 
-    - <<: *compile-tests
-      name: "Compile Regression and Compliance tests - ARM_MUSCA_B1"
-      env: TARGET_NAME=ARM_MUSCA_B1 CACHE_NAME=ARM_MUSCA_B1
+    # Temporarily disabled due to target rename in TF-M
+    # - <<: *compile-tests
+    #   name: "Compile Regression and Compliance tests - ARM_MUSCA_B1"
+    #   env: TARGET_NAME=ARM_MUSCA_B1 CACHE_NAME=ARM_MUSCA_B1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,6 @@ if ("${MBED_CONFIG_DEFINITIONS}" MATCHES "MBED_CONF_APP_REGRESSION_TEST=1")
         tfm_qcbor_test
         tfm_t_cose_test
         platform_ns
-        psa_api_ns
         tfm_ns_integration_test
         tfm_qcbor
         tfm_t_cose

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -70,8 +70,8 @@ def _clone_tfm_repo(commit):
     Clone TF-M git repos and it's dependencies
     :param commit: If True then commit VERSION.txt
     """
-    check_and_clone_repo("trusted-firmware-m", "mbed-tfm", TF_M_BUILD_DIR)
-    check_and_clone_repo("tf-m-tests", "mbed-tfm", TF_M_BUILD_DIR)
+    check_and_clone_repo("trusted-firmware-m", "upstream-tfm", TF_M_BUILD_DIR)
+    check_and_clone_repo("tf-m-tests", "upstream-tfm", TF_M_BUILD_DIR)
     check_and_clone_repo(
         "psa-arch-tests", "psa-api-compliance", TF_M_BUILD_DIR
     )

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -519,6 +519,23 @@ def _copy_library(source, toolchain):
 
                 shutil.copy2(src_file, dst_file)
 
+                if dst_base == "libplatform_ns.ar":
+                    # TF-M redirects output to serial by declaring its own `FILE __stdout`
+                    # and disables the toolchain's default version of this symbol using
+                    # the flag `-nostdlib`. But stdlib is enabled and required by Mbed OS,
+                    # so we need to disable the one from TF-M's libplatform_ns to avoid
+                    # symbol duplication.
+                    cmd = [
+                        "fromelf",
+                        "--elf",
+                        "--localize",
+                        "__stdout",
+                        dst_file,
+                        "-o",
+                        dst_file,
+                    ]
+                    run_cmd_and_return(cmd)
+
 
 def _build_target(tgt, cmake_build_dir, args):
     """

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -350,7 +350,7 @@ def _copy_binaries(source, destination, toolchain, target):
             install_dir = join(install_dir, os.pardir)
             head_tail = split(head_tail[0])
 
-        tfm_veneer = join(install_dir, "export", "tfm", "lib", "s_veneers.o")
+        tfm_veneer = join(install_dir, "interface", "lib", "s_veneers.o")
         shutil.copy2(tfm_veneer, output_dir)
 
 

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -226,7 +226,6 @@ def _run_cmake_build(cmake_build_dir, args, tgt, tfm_config):
             [
                 "-DTEST_NS=ON",
                 "-DTEST_S=ON",
-                "-DTFM_IRQ_TEST=ON",
                 "-DTFM_PERIPH_ACCESS_TEST=ON",
             ]
         )

--- a/main.cpp
+++ b/main.cpp
@@ -26,10 +26,6 @@ int main(void)
     GREENTEA_SETUP(600, "default_auto");
 #endif
 
-    // Use TF-M regression test TIMER1 IRQ handler for the TIMER1 IRQ. The TF-M
-    // IRQ test requires its own handler to be installed.
-    NVIC_SetVector(TFM_TIMER1_IRQ, (uint32_t)TIMER1_Handler);
-
     tfm_log_printf("Starting TF-M regression tests\n");
 
     // Disable deep sleep to avoid the TF-M IRQ test causing a hang, as the

--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -18,21 +18,21 @@
     "mbed-os": {
         "ARM_MUSCA_S1": [
             {
-                "src": "bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o",
+                "src": "install/image_signing/layout_files/signing_layout_ns.o",
                 "dst": "targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/partition/signing_layout_ns.c"
             },
             {
-                "src": "bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o",
+                "src": "install/image_signing/layout_files/signing_layout_s.o",
                 "dst": "targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/partition/signing_layout_s.c"
             }
         ],
         "ARM_MUSCA_B1": [
             {
-                "src": "bl2/ext/mcuboot/CMakeFiles/signing_layout_ns.dir/signing_layout_ns.o",
+                "src": "install/image_signing/layout_files/signing_layout_ns.o",
                 "dst": "targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/signing_layout_ns.c"
             },
             {
-                "src": "bl2/ext/mcuboot/CMakeFiles/signing_layout_s.dir/signing_layout_s.o",
+                "src": "install/image_signing/layout_files/signing_layout_s.o",
                 "dst": "targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/signing_layout_s.c"
             }
         ],
@@ -49,32 +49,36 @@
         ],
         "common": [
             {
-                "src": "install/export/tfm/src/tfm_crypto_ipc_api.c",
+                "src": "install/interface/src/tfm_crypto_ipc_api.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/src/tfm_crypto_ipc_api.c"
             },
             {
-                "src": "install/export/tfm/src/tfm_initial_attestation_ipc_api.c",
+                "src": "install/interface/src/tfm_initial_attestation_ipc_api.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/src/tfm_initial_attestation_ipc_api.c"
             },
             {
-                "src": "install/export/tfm/src/tfm_ps_ipc_api.c",
-                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/src/tfm_ps_ipc_api.c"
-            },
-            {
-                "src": "install/export/tfm/src/tfm_its_ipc_api.c",
+                "src": "install/interface/src/tfm_its_ipc_api.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/src/tfm_its_ipc_api.c"
             },
             {
-                "src": "install/export/tfm/src/tfm_platform_ipc_api.c",
+                "src": "install/interface/src/tfm_ps_ipc_api.c",
+                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/src/tfm_ps_ipc_api.c"
+            },
+            {
+                "src": "install/interface/src/tfm_platform_ipc_api.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/src/tfm_platform_ipc_api.c"
             },
             {
-                "src": "../bl2/ext/mcuboot/scripts/assemble.py",
+                "src": "install/image_signing/scripts/assemble.py",
                 "dst": "tools/psa/tfm/bin_utils/assemble.py"
             },
             {
-                "src": "../bl2/ext/mcuboot/scripts/macro_parser.py",
+                "src": "install/image_signing/scripts/macro_parser.py",
                 "dst": "tools/psa/tfm/bin_utils/macro_parser.py"
+            },
+            {
+                "src": "install/image_signing/scripts/wrapper/wrapper.py",
+                "dst": "tools/psa/tfm/bin_utils/wrapper.py"
             },
             {
                 "src": "lib/ext/mcuboot-src/scripts/imgtool.py",
@@ -89,11 +93,7 @@
                 "dst": "tools/psa/tfm/bin_utils/imgtool/keys"
             },
             {
-                "src": "../bl2/ext/mcuboot/scripts/wrapper/wrapper.py",
-                "dst": "tools/psa/tfm/bin_utils/wrapper.py"
-            },
-            {
-                "src": "install/export/tfm/include",
+                "src": "install/interface/include",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include"
             },
             {
@@ -101,11 +101,11 @@
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/os_wrapper"
             },
             {
-                "src": "install/export/tfm/include/psa",
+                "src": "install/interface/include/psa",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa"
             },
             {
-                "src": "install/export/tfm/include/psa_manifest",
+                "src": "install/interface/include/psa_manifest",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa_manifest"
             },
             {
@@ -115,34 +115,46 @@
         ],
         "v8-m": [
             {
-                "src": "install/export/tfm/src/tfm_psa_ns_api.c",
+                "src": "install/interface/src/tfm_psa_ns_api.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_V8M/src/tfm_psa_ns_api.c"
             },
             {
-                "src": "install/export/tfm/src/tfm_ns_interface.c",
+                "src": "install/interface/src/tfm_ns_interface.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_V8M/src/tfm_ns_interface.c"
             }
         ],
         "dualcpu": [
             {
-                "src": "install/export/tfm/src/tfm_multi_core_api.c",
-                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/tfm_multi_core_api.c"
+                "src": "install/interface/src/platform_multicore.c",
+                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/platform_multicore.c"
             },
             {
-                "src": "install/export/tfm/src/platform_ns_mailbox.c",
+                "src": "install/interface/src/platform_ns_mailbox.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/platform_ns_mailbox.c"
             },
             {
-                "src": "install/export/tfm/src/tfm_multi_core_psa_ns_api.c",
+                "src": "install/interface/src/tfm_multi_core_ns_api.c",
+                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/tfm_multi_core_ns_api.c"
+            },
+            {
+                "src": "install/interface/src/tfm_multi_core_psa_ns_api.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/ARGET_TFM_DUALCPU/src/tfm_multi_core_psa_ns_api.c"
             },
             {
-                "src": "install/export/tfm/src/tfm_ns_mailbox.c",
+                "src": "install/interface/src/tfm_ns_mailbox.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/tfm_ns_mailbox.c"
             },
             {
-                "src": "install/export/tfm/src/platform_multicore.c",
-                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/platform_multicore.c"
+                "src": "install/interface/src/tfm_ns_mailbox_rtos_api.c",
+                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/tfm_ns_mailbox_rtos_api.c"
+            },
+            {
+                "src": "install/interface/src/tfm_ns_mailbox_test.c",
+                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/tfm_ns_mailbox_test.c"
+            },
+            {
+                "src": "install/interface/src/tfm_ns_mailbox_thread.c",
+                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_DUALCPU/src/tfm_ns_mailbox_thread.c"
             }
         ]
     },
@@ -178,25 +190,21 @@
                 "dst": "tfm/platform/include/tfm_plat_ns.h"
             },
             {
-                "src": "../../tf-m-tests/test/test_services/tfm_secure_client_service/tfm_secure_client_service_api.h",
+                "src": "../tf-m-tests/test/test_services/tfm_secure_client_service/tfm_secure_client_service_api.h",
                 "dst": "test/inc"
             },
             {
-                "src": "../../tf-m-tests/test/framework/test_framework_error_codes.h",
+                "src": "../tf-m-tests/test/framework/test_framework_error_codes.h",
                 "dst": "test/inc"
             },
             {
-                "src": "../../tf-m-tests/test/framework/test_framework_integ_test.h",
+                "src": "../tf-m-tests/test/framework/test_framework_integ_test.h",
                 "dst": "test/inc"
             }
         ],
         "regression_libs": [
             {
                 "src": "app/libtfm_ns_integration_test.a",
-                "dst": "test/lib"
-            },
-            {
-                "src": "interface/libpsa_api_ns.a",
                 "dst": "test/lib"
             },
             {


### PR DESCRIPTION
This PR
* ~enables the IPC suites for Musca S1 (whose support was supported recently)~
Note: temporarily _disabled_ again, as it can't run due to an issue in MRAM fast-read...
* switches to fetch vanilla TF-M
* updates the list of test files
* disables unsupported IRQ tests (not supported for by TF-M in PSA mode anymore)

Notes:
* Preceding PR: https://github.com/ARMmbed/mbed-os/pull/14396 (merged)
* This is _not_ compatible with the current TF-M v1.2, which is why we have a separate branch. Once TF-M v1.3 is released, we will then be able to merge this to the master branch.