### PR TITLE
Reduce test timeout to 90 seconds

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@ int main(void)
 {
 #if MBED_CONF_APP_WAIT_FOR_SYNC
     tfm_log_printf("Waiting for Greentea host\n");
-    GREENTEA_SETUP(600, "default_auto");
+    GREENTEA_SETUP(90, "default_auto");
 #endif
 
     // Use TF-M regression test TIMER1 IRQ handler for the TIMER1 IRQ. The TF-M
@@ -57,7 +57,7 @@ int main(void)
 {
 #if MBED_CONF_APP_WAIT_FOR_SYNC
     tfm_log_printf("Waiting for Greentea host\n");
-    GREENTEA_SETUP(600, "default_auto");
+    GREENTEA_SETUP(90, "default_auto");
 #endif
 
     // Disable deep sleep


### PR DESCRIPTION
The timeout set in the application is sent to the Greentea test host, becoming the maximum number of seconds the host will wait before getting expected test results.

Currently TF-M Regression and PSA Compliance tests take less than 20 seconds each, so there is no point waiting 600 seconds. The reduced timeout is still sufficient and speeds up retries (if enabled).

Note: The intention is use `--retry-count` in CI as storage on Musca S1 is sometimes unstable. It's not added to this PR because it may not be needed on local boards.