### PR TITLE
Enable the PSA IPC suite on Musca S1

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ python3 test_psa_target.py -h
 
 When you automate all tests, the Greentea test tool compares the test results with the logs in [`test/logs`](./test/logs) and prints a test report. *All test suites should pass*, except for the following suites that are currently **excluded** from the run:
 
-* PSA IPC suite on Musca S1: Not currently supported.
 * PSA Crypto suite: Some test cases are known to crash and reboot the target. This
 causes the Greentea test framework to lose synchronization, and the residual data in the
 memory prevents subsequent suites from running.

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -735,14 +735,6 @@ def _main():
     parser = _get_parser()
     args = parser.parse_args()
 
-    # Issue : https://github.com/ARMmbed/mbed-os-tf-m-regression-tests/issues/49
-    # There is no support for this target to run Firmware Framework tests
-    if args.suite == "IPC" and args.mcu == "ARM_MUSCA_S1":
-        logging.info(
-            "%s config is not supported for %s target" % (args.suite, args.mcu)
-        )
-        return
-
     if args.list:
         logging.info(
             "Supported TF-M regression targets are: {}".format(

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -67,7 +67,7 @@ dependencies = {
     "psa-api-compliance": {
         "psa-arch-tests": [
             "https://github.com/ARM-software/psa-arch-tests.git",
-            "Before_Crypto_1.0",
+            "master",
         ],
     },
 }

--- a/test/logs/ARM_MUSCA_S1/IPC.log
+++ b/test/logs/ARM_MUSCA_S1/IPC.log
@@ -1,0 +1,6 @@
+IPC Suite Report
+TOTAL TESTS     : [0-9]+
+TOTAL PASSED    : [0-9]+
+TOTAL SIM ERROR : 0
+TOTAL FAILED    : 0
+TOTAL SKIPPED   : 1

--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -305,14 +305,6 @@ def _build_compliance_test(args, test_spec):
 
     for suite in PSA_SUITE_CHOICES:
 
-        # Issue : https://github.com/ARMmbed/mbed-os-tf-m-regression-tests/issues/49
-        # There is no support for this target to run Firmware Framework tests
-        if suite == "IPC" and args.mcu == "ARM_MUSCA_S1":
-            logging.info(
-                "%s config is not supported for %s target" % (suite, args.mcu)
-            )
-            continue
-
         logging.info("Build PSA Compliance - %s suite for %s", suite, args.mcu)
 
         _build_tfm(args, "PsaApiTestIPC", suite)


### PR DESCRIPTION
Fixes: #49 

Support for the PSA IPC suite on Musca S1 has recently been added to trusted-firmware-m and psa-arch-tests. This PR enables it on the _latest TF-M_ + Mbed OS continuous integration branch whose commits will be eventually used for TF-M v1.3.

@ARMmbed/mbed-os-core 