### PR TITLE
Refactor fetching of trusted-firmware-m

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -71,7 +71,7 @@ def _clone_tfm_repo(commit):
     Clone TF-M git repos and it's dependencies
     :param commit: If True then commit VERSION.txt
     """
-    check_and_clone_repo("trusted-firmware-m", "upstream-tfm", TF_M_BUILD_DIR)
+    check_and_clone_repo("trusted-firmware-m", "latest-tfm", TF_M_BUILD_DIR)
 
     _detect_and_write_tfm_version(
         join(TF_M_BUILD_DIR, "trusted-firmware-m"), commit

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -66,38 +66,12 @@ def _detect_and_write_tfm_version(tfm_dir, commit):
         _commit_changes(VERSION_FILE_PATH)
 
 
-def _patch_psa_arch_tests(psa_arch_tests_dir, tfm_dir):
-    """
-    Apply patches to psa-arch-tests required by trusted-firmware-m
-    """
-    patches = glob.glob(
-        join(tfm_dir, "lib", "ext", "psa_arch_tests", "*.patch")
-    )
-    if patches:
-        cmd = [
-            "git",
-            "-C",
-            psa_arch_tests_dir,
-            "apply",
-        ] + patches
-        run_cmd_and_return(cmd)
-
-
 def _clone_tfm_repo(commit):
     """
     Clone TF-M git repos and it's dependencies
     :param commit: If True then commit VERSION.txt
     """
     check_and_clone_repo("trusted-firmware-m", "upstream-tfm", TF_M_BUILD_DIR)
-    check_and_clone_repo("tf-m-tests", "upstream-tfm", TF_M_BUILD_DIR)
-    check_and_clone_repo(
-        "psa-arch-tests", "psa-api-compliance", TF_M_BUILD_DIR
-    )
-
-    _patch_psa_arch_tests(
-        join(TF_M_BUILD_DIR, "psa-arch-tests"),
-        join(TF_M_BUILD_DIR, "trusted-firmware-m"),
-    )
 
     _detect_and_write_tfm_version(
         join(TF_M_BUILD_DIR, "trusted-firmware-m"), commit
@@ -242,7 +216,6 @@ def _run_cmake_build(cmake_build_dir, args, tgt, tfm_config):
     cmake_cmd = ["cmake", "../", "-GNinja", "-DTFM_PSA_API=ON"]
     cmake_cmd.append("-DTFM_PLATFORM=" + tgt[1])
     cmake_cmd.append("-DTFM_TOOLCHAIN_FILE=../toolchain_" + tgt[2] + ".cmake")
-    cmake_cmd.append("-DTFM_TEST_REPO_PATH=../../tf-m-tests")
 
     if args.config == SUPPORTED_TFM_CONFIGS[1]:
         cmake_cmd.extend(
@@ -264,8 +237,6 @@ def _run_cmake_build(cmake_build_dir, args, tgt, tfm_config):
         cmake_cmd.append("-DBL2=True")
 
     if args.config in SUPPORTED_TFM_PSA_CONFIGS:
-        cmake_cmd.append("-DPSA_ARCH_TESTS_PATH=../../psa-arch-tests")
-
         if args.suite in PSA_SUITE_CHOICES:
             cmake_cmd.append("-DTEST_PSA_API=" + args.suite)
 

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -32,41 +32,17 @@ except ImportError as e:
     exit(1)
 
 dependencies = {
-    # If the remote repo is changed, please delete TARGET_IGNORE folder.
+    # If the remote repo is changed, please delete tfm/repos/trusted-firmware-m.
     # Quick switch between remotes is not supported.
-    "mbed-tfm": {
-        "trusted-firmware-m": [
-            "https://github.com/ARMmbed/trusted-firmware-m.git",
-            "mbed-tfm-1.2",
-        ],
-        "tf-m-tests": [
-            "https://github.com/ARMmbed/tf-m-tests.git",
-            "mbed-tfm-1.2",
-        ],
-    },
-    "mbed-tfm-rebase": {
-        "trusted-firmware-m": [
-            "https://github.com/ARMmbed/trusted-firmware-m.git",
-            "mbed-tfm-rebase-check",
-        ],
-        "tf-m-tests": [
-            "https://github.com/ARMmbed/tf-m-tests.git",
-            "mbed-tfm-rebase-check",
-        ],
-    },
-    "upstream-tfm": {
+    "released-tfm": {
         "trusted-firmware-m": [
             "https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git",
-            "master",
-        ],
-        "tf-m-tests": [
-            "https://git.trustedfirmware.org/TF-M/tf-m-tests.git",
-            "master",
+            "TF-Mv1.3.0",
         ],
     },
-    "psa-api-compliance": {
-        "psa-arch-tests": [
-            "https://github.com/ARM-software/psa-arch-tests.git",
+    "latest-tfm": {
+        "trusted-firmware-m": [
+            "https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git",
             "master",
         ],
     },

--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -109,7 +109,7 @@
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa_manifest"
             },
             {
-                "src": "../../tf-m-tests/app/os_wrapper_cmsis_rtos_v2.c",
+                "src": "lib/ext/tfm_test_repo-src/app/os_wrapper_cmsis_rtos_v2.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/src/os_wrapper_cmsis_rtos_v2.c"
             }
         ],
@@ -190,15 +190,15 @@
                 "dst": "tfm/platform/include/tfm_plat_ns.h"
             },
             {
-                "src": "../tf-m-tests/test/test_services/tfm_secure_client_service/tfm_secure_client_service_api.h",
+                "src": "cmake_build/lib/ext/tfm_test_repo-src/test/test_services/tfm_secure_client_service/tfm_secure_client_service_api.h",
                 "dst": "test/inc"
             },
             {
-                "src": "../tf-m-tests/test/framework/test_framework_error_codes.h",
+                "src": "cmake_build/lib/ext/tfm_test_repo-src/test/framework/test_framework_error_codes.h",
                 "dst": "test/inc"
             },
             {
-                "src": "../tf-m-tests/test/framework/test_framework_integ_test.h",
+                "src": "cmake_build/lib/ext/tfm_test_repo-src/test/framework/test_framework_integ_test.h",
                 "dst": "test/inc"
             }
         ],


### PR DESCRIPTION
This PR does the following:
* Use trusted-firmware-m's own version control - The build system of trusted-firmware-m tracks specific versions of dependencies. This _fixes our nightly CI failure_ due to the latest psa-arch-tests not compiling with the latest trusted-firmware-m.
* Clean up version tracking of trusted-firmware-m - Now the only thing to fetch is https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git. Note: Not backward compatible with TF-M v1.2, but the tfm_latest_integration_check branch is CI-only, and some other parts of the scripts on this branch don't work with TF-M v1.2 anyway. The current master branch is for production and works with TF-M v1.2.
* Handle switching of git remote - We renamed remotes in the previous commit and a few times before, but the failure (due to remote not found) isn't obvious to users.

See commit messages for details.