### PR TITLE
vagrant: Use cryptography from Ubuntu package registry

### DIFF
--- a/vagrant/bootstrap-user.sh
+++ b/vagrant/bootstrap-user.sh
@@ -7,4 +7,4 @@ mkdir -p ~/.local
 mv gcc-arm-none-eabi-9-2019-q4-major/* ~/.local/
 
 # Python environment
-python3 -m pip install --user cryptography pyasn1 pyyaml jinja2 cbor mbed-cli mbed-tools
+python3 -m pip install --user pyasn1 pyyaml jinja2 cbor mbed-cli mbed-tools

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -12,6 +12,7 @@ apt-get install -y \
 	git \
 	mercurial \
 	python3-pip \
+	python-cryptography \
 	srecord \
 	unzip \
 	ninja-build \


### PR DESCRIPTION
The latest version of cryptography requires Rust to be installed and is
not guaranteed to work with other Ubuntu compatible python packages.
Instead we should use the version of cryptography from the Ubuntu
package registry, as that version has been verified to work on the
version of Ubuntu used in vagrant.