### PR TITLE
Use the latest TF-M for continuous integration

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -70,7 +70,7 @@ def _clone_tfm_repo(commit):
     Clone TF-M git repos and it's dependencies
     :param commit: If True then commit VERSION.txt
     """
-    check_and_clone_repo("trusted-firmware-m", "released-tfm", TF_M_BUILD_DIR)
+    check_and_clone_repo("trusted-firmware-m", "latest-tfm", TF_M_BUILD_DIR)
 
     _detect_and_write_tfm_version(
         os.path.join(TF_M_BUILD_DIR, "trusted-firmware-m"), commit

--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -97,10 +97,6 @@
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include"
             },
             {
-                "src": "../interface/include/os_wrapper",
-                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/os_wrapper"
-            },
-            {
                 "src": "install/interface/include/psa",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/psa"
             },
@@ -111,6 +107,14 @@
             {
                 "src": "lib/ext/tfm_test_repo-src/app/os_wrapper_cmsis_rtos_v2.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/src/os_wrapper_cmsis_rtos_v2.c"
+            },
+            {
+                "src": "lib/ext/tfm_test_repo-src/ns_interface/os_wrapper",
+                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/os_wrapper"
+            },
+            {
+                "src": "../interface/include/tfm_psa_call_param.h",
+                "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/include/tfm_psa_call_param.h"
             }
         ],
         "v8-m": [
@@ -119,7 +123,7 @@
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_V8M/src/tfm_psa_ns_api.c"
             },
             {
-                "src": "install/interface/src/tfm_ns_interface.c",
+                "src": "lib/ext/tfm_test_repo-src/app/tfm_ns_interface.c",
                 "dst": "platform/FEATURE_EXPERIMENTAL_API/FEATURE_PSA/TARGET_TFM/TARGET_TFM_LATEST/TARGET_TFM_V8M/src/tfm_ns_interface.c"
             }
         ],


### PR DESCRIPTION
The branch [tfm_latest_integration_check](https://github.com/ARMmbed/mbed-os-tf-m-regression-tests/tree/tfm_latest_integration_check) serves to test the latest development version (the master branch) of TF-M against Mbed OS, enabling us to perform any integration work early before the next release.

As a result of the branch switch, the locations of some of the files to import from TF-M have changed and this PR also updates the list.