### PR TITLE
Musca B1: Add firmware update to Regression test log

### DIFF
--- a/test/logs/ARM_MUSCA_B1/REGRESSION.log
+++ b/test/logs/ARM_MUSCA_B1/REGRESSION.log
@@ -6,6 +6,7 @@ Test suite 'Platform Service Non-Secure interface tests\(TFM_PLATFORM_TEST_2XXX\
 Test suite 'Initial Attestation Service non-secure interface tests\(TFM_ATTEST_TEST_2XXX\)' has .* PASSED
 Test suite 'QCBOR regression test\(TFM_QCBOR_TEST_7XXX\)' has .* PASSED
 Test suite 'T_COSE regression test\(TFM_T_COSE_TEST_8XXX\)' has .* PASSED
+Test suite 'PSA firmware update NS interface tests \(TFM_FWU_TEST_1xxx\)' has .* PASSED
 Test suite 'Core non-secure positive tests \(TFM_CORE_TEST_1XXX\)' has .* PASSED
 Test suite 'IPC non-secure interface test \(TFM_IPC_TEST_1XXX\)' has .* PASSED
 End of Non-secure test suites


### PR DESCRIPTION
The PSA Firmware Update (FWU) API and tests are available on Musca B1.

Without this change the Greentea test runner still treats the tests as a pass as long as the other lines match the serial output, but we add it for completeness.