### PR TITLE
Update TF-M Regression Tests logs

### DIFF
--- a/test/logs/ARM_MUSCA_B1/REGRESSION.log
+++ b/test/logs/ARM_MUSCA_B1/REGRESSION.log
@@ -1,12 +1,12 @@
 Non-secure test suites summary
-Test suite 'PSA protected storage NS interface tests \(TFM_PS_TEST_1XXX\)' has .* PASSED
-Test suite 'PSA internal trusted storage NS interface tests \(TFM_ITS_TEST_1XXX\)' has .* PASSED
-Test suite 'Crypto non-secure interface test \(TFM_CRYPTO_TEST_6XXX\)' has .* PASSED
-Test suite 'Platform Service Non-Secure interface tests\(TFM_PLATFORM_TEST_2XXX\)' has .* PASSED
-Test suite 'Initial Attestation Service non-secure interface tests\(TFM_ATTEST_TEST_2XXX\)' has .* PASSED
-Test suite 'QCBOR regression test\(TFM_QCBOR_TEST_7XXX\)' has .* PASSED
-Test suite 'T_COSE regression test\(TFM_T_COSE_TEST_8XXX\)' has .* PASSED
-Test suite 'PSA firmware update NS interface tests \(TFM_FWU_TEST_1xxx\)' has .* PASSED
-Test suite 'Core non-secure positive tests \(TFM_CORE_TEST_1XXX\)' has .* PASSED
-Test suite 'IPC non-secure interface test \(TFM_IPC_TEST_1XXX\)' has .* PASSED
+Test suite 'PSA protected storage NS interface tests \(TFM_NS_PS_TEST_1XXX\)' has .* PASSED
+Test suite 'PSA internal trusted storage NS interface tests \(TFM_NS_ITS_TEST_1XXX\)' has .* PASSED
+Test suite 'Crypto non-secure interface test \(TFM_NS_CRYPTO_TEST_1XXX\)' has .* PASSED
+Test suite 'Platform Service Non-Secure interface tests\(TFM_NS_PLATFORM_TEST_1XXX\)' has .* PASSED
+Test suite 'Initial Attestation Service non-secure interface tests\(TFM_NS_ATTEST_TEST_1XXX\)' has .* PASSED
+Test suite 'QCBOR regression test\(TFM_NS_QCBOR_TEST_1XXX\)' has .* PASSED
+Test suite 'T_COSE regression test\(TFM_NS_T_COSE_TEST_1XXX\)' has .* PASSED
+Test suite 'PSA firmware update NS interface tests \(TFM_NS_FWU_TEST_1xxx\)' has .* PASSED
+Test suite 'Core non-secure positive tests \(TFM_NS_CORE_TEST_1XXX\)' has .* PASSED
+Test suite 'IPC non-secure interface test \(TFM_NS_IPC_TEST_1XXX\)' has .* PASSED
 End of Non-secure test suites

--- a/test/logs/ARM_MUSCA_S1/REGRESSION.log
+++ b/test/logs/ARM_MUSCA_S1/REGRESSION.log
@@ -1,11 +1,11 @@
 Non-secure test suites summary
-Test suite 'PSA protected storage NS interface tests \(TFM_PS_TEST_1XXX\)' has .* PASSED
-Test suite 'PSA internal trusted storage NS interface tests \(TFM_ITS_TEST_1XXX\)' has .* PASSED
-Test suite 'Crypto non-secure interface test \(TFM_CRYPTO_TEST_6XXX\)' has .* PASSED
-Test suite 'Platform Service Non-Secure interface tests\(TFM_PLATFORM_TEST_2XXX\)' has .* PASSED
-Test suite 'Initial Attestation Service non-secure interface tests\(TFM_ATTEST_TEST_2XXX\)' has .* PASSED
-Test suite 'QCBOR regression test\(TFM_QCBOR_TEST_7XXX\)' has .* PASSED
-Test suite 'T_COSE regression test\(TFM_T_COSE_TEST_8XXX\)' has .* PASSED
-Test suite 'Core non-secure positive tests \(TFM_CORE_TEST_1XXX\)' has .* PASSED
-Test suite 'IPC non-secure interface test \(TFM_IPC_TEST_1XXX\)' has .* PASSED
+Test suite 'PSA protected storage NS interface tests \(TFM_NS_PS_TEST_1XXX\)' has .* PASSED
+Test suite 'PSA internal trusted storage NS interface tests \(TFM_NS_ITS_TEST_1XXX\)' has .* PASSED
+Test suite 'Crypto non-secure interface test \(TFM_NS_CRYPTO_TEST_1XXX\)' has .* PASSED
+Test suite 'Platform Service Non-Secure interface tests\(TFM_NS_PLATFORM_TEST_1XXX\)' has .* PASSED
+Test suite 'Initial Attestation Service non-secure interface tests\(TFM_NS_ATTEST_TEST_1XXX\)' has .* PASSED
+Test suite 'QCBOR regression test\(TFM_NS_QCBOR_TEST_1XXX\)' has .* PASSED
+Test suite 'T_COSE regression test\(TFM_NS_T_COSE_TEST_1XXX\)' has .* PASSED
+Test suite 'Core non-secure positive tests \(TFM_NS_CORE_TEST_1XXX\)' has .* PASSED
+Test suite 'IPC non-secure interface test \(TFM_NS_IPC_TEST_1XXX\)' has .* PASSED
 End of Non-secure test suites


### PR DESCRIPTION
The latest TF-M has renamed the identifier of each test suite.

This fixes the regression tests in the nightly CI for the latest development version of TF-M + Mbed OS.