### PR TITLE
Update path to libtfm_test_suite_fwu_ns.a

### DIFF
--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -216,7 +216,7 @@
                 "dst": "test/lib"
             },
             {
-                "src": "test/suites/fwu/libtfm_test_suite_fwu_ns.a",
+                "src": "test/suites/fwu/mcuboot/libtfm_test_suite_fwu_ns.a",
                 "dst": "test/lib"
             },
             {


### PR DESCRIPTION
The path containing the library tfm_test_suite_fwu_ns has been moved in tf-m-tests.