### PR TITLE
Workarounds for renamed Musca targets, Mbed CLI 1 failure

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,0 +1,1 @@
+mbed-os/connectivity/mbedtls/source/*

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -28,6 +28,14 @@ from psa_builder import *
 from tools.toolchains import TOOLCHAIN_PATHS
 from tools.targets import TARGET_MAP
 
+# TEMPORARY: Targets have been renamed in the development version
+# of trusted-firmware-m, but mbed-os tracks the target names in
+# the current released version. This workaround should only live on
+# the tfm_latest_integration_check branch, and it's to be removed
+# once we update mbed-os/targets/targets.json for the next TF-M release.
+TARGET_MAP["ARM_MUSCA_B1"].tfm_target_name = "arm/musca_b1/sse_200"
+TARGET_MAP["ARM_MUSCA_S1"].tfm_target_name = "arm/musca_s1"
+
 logging.basicConfig(
     level=logging.INFO,
     format="[Build-TF-M] %(asctime)s: %(message)s.",


### PR DESCRIPTION
This PR fixes the following:
* _CI BRANCH ONLY: Workaround for renamed Musca targets_: The latest development version of TF-M has moved "musca_s1" and "musca_b" into the "arm" subdirectory which becomes part of the target names. But `tfm_target_name`s in `targets.json` of Mbed OS track the released version of TF-M (v1.3.0 at this point).
The temporary workaround is to hardcode the values in `build_tfm.py` on the tfm_latest_integration_check branch to unblock nightly CI. This will be removed when the next TF-M release becomes available and we update `targets.json` in Mbed OS.
* _Mbed CLI 1: Ignore Mbed TLS source_: The PSA headers from trusted-firmware-m are not currently fully compatible with the Mbed TLS source code, lacking some definitions in crypto headers. Normally, when we upgrade TF-M in mbed-os to a new release (e.g. v1.3.0), we make changes to the headers so that normal applications can work with both TF-M and Mbed TLS.
But mbed-os-tf-m-regression-tests directly imports PSA headers from TF-M as part of the build process, overriding the existing PSA headers in mbed-os. Add `.mbedignore` to ensure Mbed CLI 1 does not compile Mbed TLS and fail.