### PR TITLE
Workaround Mbed CLI 1 build, drop requirement of "make"

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,0 +1,1 @@
+mbed-os/connectivity/mbedtls/source/*

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -81,14 +81,6 @@ def are_dependencies_installed():
         command = ["cmake", "--version"]
         return run_cmd_and_return(command)
 
-    def _is_make_installed():
-        """
-        Check if GNU Make is installed
-        :return: errorcode
-        """
-        command = ["make", "--version"]
-        return run_cmd_and_return(command)
-
     def _is_git_installed():
         """
         Check if git is installed
@@ -126,9 +118,6 @@ def are_dependencies_installed():
         return -1
     elif _is_cmake_installed() != 0:
         logging.error('"Cmake" is not installed. Exiting..')
-        return -1
-    elif _is_make_installed() != 0:
-        logging.error('"Make" is not installed. Exiting..')
         return -1
     elif _is_srec_installed() != 0:
         logging.error('"srec_cat" is not installed. Exiting..')


### PR DESCRIPTION
* Work around Mbed CLI 1 build error, due to PSA header incompatibility with Mbed TLS. Cherry picked from 564233bff389d9db6be5b2b0065de54c761dedce on the tfm_latest_integration_check branch.
* Drop the requirement of "make", as we now use "ninja" as the CMake generator.