### PR TITLE
CMake: Fix linking of greentea, unity and utest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,10 @@ target_link_libraries(${APP_TARGET}
     PRIVATE
         mbed-os
         mbed-psa
-        mbed-greentea
+        mbed-unity
+        mbed-utest
+        mbed-greentea-io
+        greentea::client_userio
 )
 
 if ("${MBED_CONFIG_DEFINITIONS}" MATCHES "MBED_CONF_APP_REGRESSION_TEST=1")


### PR DESCRIPTION
Requires: https://github.com/ARMmbed/mbed-os/pull/14880

The test application uses the greentea client for synchronization with the host and unity for assertions, and unity in Mbed OS contains references to utest. We have recently split them from one mbed-greentea library into three, so the test application needs to link all of them.

Notes:
* The communication between device and host does not currently work, because currently the integration of [greentea-client](https://github.com/ARMmbed/greentea-client) + Mbed OS has an I/O issue. Nonetheless, it does not affect this PR because the version of greentea-client is controlled by Mbed OS which we always use the latest version of.
* Once this gets in, we need to rebase the branch tfm_latest_integration_check to take advantage of the fix too.