### PR TITLE
Update the list of files to import, enable PSA Crypto suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,12 +67,12 @@ if ("${MBED_CONFIG_DEFINITIONS}" MATCHES "MBED_CONF_APP_REGRESSION_TEST=1")
         platform_ns
         tfm_ns_integration_test
         tfm_qcbor
-        tfm_t_cose
     )
     # Firmware Update test supports Musca B1 only
     if(${MBED_TARGET} STREQUAL ARM_MUSCA_B1)
         list(APPEND TEST_LIBS
             tfm_test_suite_fwu_ns
+            tfm_test_suite_irq
             tfm_api_ns
         )
     endif()

--- a/README.md
+++ b/README.md
@@ -174,17 +174,7 @@ python3 test_psa_target.py -h
 
 ## Expected test results
 
-When you automate all tests, the Greentea test tool compares the test results with the logs in [`test/logs`](./test/logs) and prints a test report. *All test suites should pass*, except for the following suites that are currently **excluded** from the run:
-
-* PSA Crypto suite: Some test cases are known to crash and reboot the target. This
-causes the Greentea test framework to lose synchronization, and the residual data in the
-memory prevents subsequent suites from running.
-
-    **Tip**: You can flash and run the PSA Crypto suite separately. Make sure
-    to build the Crypto suite manually with `wait-for-sync` set to 0 in
-    `mbed_app.json`, and power cycle the target before and after
-    the run to clear the memory. The total number of failures should match
-    `CRYPTO.log` in [`test/logs`](./test/logs)`/<your-target>`.
+When you automate all tests, the Greentea test tool compares the test results with the logs in [`test/logs`](./test/logs) and prints a test report. *All test suites should pass or match the numbers of known failures in the logs.*
 
 ## Troubleshooting
 

--- a/test/logs/ARM_MUSCA_B1/CRYPTO.log
+++ b/test/logs/ARM_MUSCA_B1/CRYPTO.log
@@ -2,5 +2,5 @@ Crypto Suite Report
 TOTAL TESTS     : [0-9]+
 TOTAL PASSED    : [0-9]+
 TOTAL SIM ERROR : 0
-TOTAL FAILED    : 18
+TOTAL FAILED    : 23
 TOTAL SKIPPED   : 0

--- a/test/logs/ARM_MUSCA_B1/REGRESSION.log
+++ b/test/logs/ARM_MUSCA_B1/REGRESSION.log
@@ -1,12 +1,12 @@
 Non-secure test suites summary
-Test suite 'PSA protected storage NS interface tests \(TFM_NS_PS_TEST_1XXX\)' has .* PASSED
-Test suite 'PSA internal trusted storage NS interface tests \(TFM_NS_ITS_TEST_1XXX\)' has .* PASSED
-Test suite 'Crypto non-secure interface test \(TFM_NS_CRYPTO_TEST_1XXX\)' has .* PASSED
-Test suite 'Platform Service Non-Secure interface tests\(TFM_NS_PLATFORM_TEST_1XXX\)' has .* PASSED
-Test suite 'Initial Attestation Service non-secure interface tests\(TFM_NS_ATTEST_TEST_1XXX\)' has .* PASSED
-Test suite 'QCBOR regression test\(TFM_NS_QCBOR_TEST_1XXX\)' has .* PASSED
-Test suite 'T_COSE regression test\(TFM_NS_T_COSE_TEST_1XXX\)' has .* PASSED
-Test suite 'PSA firmware update NS interface tests \(TFM_NS_FWU_TEST_1xxx\)' has .* PASSED
-Test suite 'Core non-secure positive tests \(TFM_NS_CORE_TEST_1XXX\)' has .* PASSED
-Test suite 'IPC non-secure interface test \(TFM_NS_IPC_TEST_1XXX\)' has .* PASSED
+Test suite 'PSA protected storage NS interface tests \(TFM_NS_PS_TEST_1XXX\)' has.*PASSED
+Test suite 'PSA internal trusted storage NS interface tests \(TFM_NS_ITS_TEST_1XXX\)' has.*PASSED
+Test suite 'Crypto non-secure interface test \(TFM_NS_CRYPTO_TEST_1XXX\)' has.*PASSED
+Test suite 'Platform Service Non-Secure interface tests\(TFM_NS_PLATFORM_TEST_1XXX\)' has.*PASSED
+Test suite 'Initial Attestation Service non-secure interface tests\(TFM_NS_ATTEST_TEST_1XXX\)' has.*PASSED
+Test suite 'QCBOR regression test\(TFM_NS_QCBOR_TEST_1XXX\)' has.*PASSED
+Test suite 'T_COSE regression test\(TFM_NS_T_COSE_TEST_1XXX\)' has.*PASSED
+Test suite 'PSA firmware update NS interface tests \(TFM_NS_FWU_TEST_1xxx\)' has.*PASSED
+Test suite 'Core non-secure positive tests \(TFM_NS_CORE_TEST_1XXX\)' has.*PASSED
+Test suite 'IPC non-secure interface test \(TFM_NS_IPC_TEST_1XXX\)' has.*PASSED
 End of Non-secure test suites

--- a/test/logs/ARM_MUSCA_S1/CRYPTO.log
+++ b/test/logs/ARM_MUSCA_S1/CRYPTO.log
@@ -2,5 +2,5 @@ Crypto Suite Report
 TOTAL TESTS     : [0-9]+
 TOTAL PASSED    : [0-9]+
 TOTAL SIM ERROR : 0
-TOTAL FAILED    : 17
+TOTAL FAILED    : 23
 TOTAL SKIPPED   : 0

--- a/test/logs/ARM_MUSCA_S1/REGRESSION.log
+++ b/test/logs/ARM_MUSCA_S1/REGRESSION.log
@@ -1,11 +1,11 @@
 Non-secure test suites summary
-Test suite 'PSA protected storage NS interface tests \(TFM_NS_PS_TEST_1XXX\)' has .* PASSED
-Test suite 'PSA internal trusted storage NS interface tests \(TFM_NS_ITS_TEST_1XXX\)' has .* PASSED
-Test suite 'Crypto non-secure interface test \(TFM_NS_CRYPTO_TEST_1XXX\)' has .* PASSED
-Test suite 'Platform Service Non-Secure interface tests\(TFM_NS_PLATFORM_TEST_1XXX\)' has .* PASSED
-Test suite 'Initial Attestation Service non-secure interface tests\(TFM_NS_ATTEST_TEST_1XXX\)' has .* PASSED
-Test suite 'QCBOR regression test\(TFM_NS_QCBOR_TEST_1XXX\)' has .* PASSED
-Test suite 'T_COSE regression test\(TFM_NS_T_COSE_TEST_1XXX\)' has .* PASSED
-Test suite 'Core non-secure positive tests \(TFM_NS_CORE_TEST_1XXX\)' has .* PASSED
-Test suite 'IPC non-secure interface test \(TFM_NS_IPC_TEST_1XXX\)' has .* PASSED
+Test suite 'PSA protected storage NS interface tests \(TFM_NS_PS_TEST_1XXX\)' has.*PASSED
+Test suite 'PSA internal trusted storage NS interface tests \(TFM_NS_ITS_TEST_1XXX\)' has.*PASSED
+Test suite 'Crypto non-secure interface test \(TFM_NS_CRYPTO_TEST_1XXX\)' has.*PASSED
+Test suite 'Platform Service Non-Secure interface tests\(TFM_NS_PLATFORM_TEST_1XXX\)' has.*PASSED
+Test suite 'Initial Attestation Service non-secure interface tests\(TFM_NS_ATTEST_TEST_1XXX\)' has.*PASSED
+Test suite 'QCBOR regression test\(TFM_NS_QCBOR_TEST_1XXX\)' has.*PASSED
+Test suite 'T_COSE regression test\(TFM_NS_T_COSE_TEST_1XXX\)' has.*PASSED
+Test suite 'Core non-secure positive tests \(TFM_NS_CORE_TEST_1XXX\)' has.*PASSED
+Test suite 'IPC non-secure interface test \(TFM_NS_IPC_TEST_1XXX\)' has.*PASSED
 End of Non-secure test suites

--- a/test_psa_target.py
+++ b/test_psa_target.py
@@ -311,16 +311,9 @@ def _build_compliance_test(args, test_spec):
         _build_mbed_os(args)
         binary_name = _erase_flash_storage(args, suite)
 
-        # Issue: https://github.com/ARM-software/psa-arch-tests/issues/252
-        # The Crypto suite is known to crash and reset the target during runs.
-        # This causes the Greentea test framework to lose synchronization, and
-        # messes up the memory and prevents subsequent suites from running.
-        # The PSA tests currently provide no option to skip known failures.
-        # Users can still run the Crypto suite manually without automation.
-        if suite != "CRYPTO":
-            test_spec["builds"][test_group]["tests"][
-                suite.lower()
-            ] = _get_test_spec(args, suite, binary_name)
+        test_spec["builds"][test_group]["tests"][
+            suite.lower()
+        ] = _get_test_spec(args, suite, binary_name)
 
 
 def _get_parser():

--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -192,10 +192,6 @@
                 "dst": "test/lib"
             },
             {
-                "src": "lib/ext/t_cose/libtfm_t_cose.a",
-                "dst": "test/lib"
-            },
-            {
                 "src": "lib/ext/t_cose/libtfm_t_cose_test.a",
                 "dst": "test/lib"
             },
@@ -221,6 +217,10 @@
             },
             {
                 "src": "test/suites/ipc/libtfm_test_suite_ipc_ns.a",
+                "dst": "test/lib"
+            },
+            {
+                "src": "test/suites/irq/libtfm_test_suite_irq.a",
                 "dst": "test/lib"
             },
             {


### PR DESCRIPTION
* _Update the list of files to import from TF-M_: Some file locations have changed in the latest development branch of TF-M.
* _Enable the Crypto suite_: The Crypto suite was disabled due to crashes that made tests unable to continue. With the latest TF-M and psa-arch-tests, it doesn't crash anymore so we can re-enable it with updated number of expected failures.
* _Fix REGRESSION.log format_: The TF-M Regression tests recently have printing fixed - now "has" and "PASSED" have exactly one space in-between instead of two.