### PR TITLE
M2354: Support Nuvoton M2354

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,5 @@ jobs:
           target: "ARM_MUSCA_S1"
       - compile:
           target: "ARM_MUSCA_B1"
+      - compile:
+          target: "NU_M2354"

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,3 +86,9 @@ matrix:
     - <<: *compile-tests
       name: "Compile Regression and Compliance tests - ARM_MUSCA_B1"
       env: TARGET_NAME=ARM_MUSCA_B1 CACHE_NAME=ARM_MUSCA_B1
+
+    # NU_M2354
+
+    - <<: *compile-tests
+      name: "Compile Regression tests - NU_M2354"
+      env: TARGET_NAME=NU_M2354 CACHE_NAME=NU_M2354

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ if(${MBED_TARGET} STREQUAL "ARM_MUSCA_B1")
     set(TFM_TARGET_INCLUDE tfm/targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/device)
 elseif(${MBED_TARGET} STREQUAL "ARM_MUSCA_S1")
     set(TFM_TARGET_INCLUDE tfm/targets/TARGET_ARM_SSG/TARGET_MUSCA_S1/device)
+elseif(${MBED_TARGET} STREQUAL "NU_M2354")
+    set(TFM_TARGET_INCLUDE tfm/targets/TARGET_NUVOTON/TARGET_NU_M2354/device)
 else()
     message(FATAL_ERROR "Unsupported target ${MBED_TARGET}")
 endif()
@@ -69,8 +71,8 @@ if ("${MBED_CONFIG_DEFINITIONS}" MATCHES "MBED_CONF_APP_REGRESSION_TEST=1")
         tfm_qcbor
         tfm_t_cose
     )
-    # Firmware Update test supports Musca B1 only
-    if(${MBED_TARGET} STREQUAL ARM_MUSCA_B1)
+    # Firmware Update test supports Musca B1/M2354 only
+    if((${MBED_TARGET} STREQUAL ARM_MUSCA_B1) OR (${MBED_TARGET} STREQUAL NU_M2354))
         list(APPEND TEST_LIBS
             tfm_test_suite_fwu_ns
             tfm_api_ns

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ to build an application that runs the test suite.
 * To see all available suites, run `python3 build_tfm.py -h`.
 * Make sure the TF-M Regression Test suite has **PASSED** on the board before
 running any PSA Compliance Test suite to avoid unpredictable behavior.
+* M2354 hasn't supported PSA compliance test yet.
 
 ## Building the Mbed OS application
 
@@ -185,6 +186,8 @@ memory prevents subsequent suites from running.
     `mbed_app.json`, and power cycle the target before and after
     the run to clear the memory. The total number of failures should match
     `CRYPTO.log` in [`test/logs`](./test/logs)`/<your-target>`.
+
+* M2354 hasn't supported PSA compliance test yet.
 
 ## Troubleshooting
 

--- a/build_tfm.py
+++ b/build_tfm.py
@@ -65,12 +65,20 @@ def _detect_and_write_tfm_version(tfm_dir, commit):
         _commit_changes(MBED_TF_M_PATH)
 
 
-def _clone_tfm_repo(commit):
+def _clone_tfm_repo(target, commit):
     """
     Clone TF-M git repos and it's dependencies
+    :param target: Target name
     :param commit: If True then commit VERSION.txt
     """
-    check_and_clone_repo("trusted-firmware-m", "released-tfm", TF_M_BUILD_DIR)
+    if target == "NU_M2354":
+        check_and_clone_repo(
+            "trusted-firmware-m", "nuvoton-tfm", TF_M_BUILD_DIR
+        )
+    else:
+        check_and_clone_repo(
+            "trusted-firmware-m", "released-tfm", TF_M_BUILD_DIR
+        )
 
     _detect_and_write_tfm_version(
         os.path.join(TF_M_BUILD_DIR, "trusted-firmware-m"), commit
@@ -612,7 +620,7 @@ def _build_tfm(args):
     """
 
     if not args.skip_clone:
-        _clone_tfm_repo(args.commit)
+        _clone_tfm_repo(args.mcu, args.commit)
 
     cmake_build_dir = os.path.join(
         TF_M_BUILD_DIR, "trusted-firmware-m", "cmake_build"

--- a/psa_builder.py
+++ b/psa_builder.py
@@ -43,6 +43,12 @@ dependencies = {
             "master",
         ],
     },
+    "nuvoton-tfm": {
+        "trusted-firmware-m": [
+            "https://github.com/OpenNuvoton/trusted-firmware-m",
+            "nuvoton_mbed_m2354_tfm-1.3",
+        ],
+    },
 }
 
 TC_DICT = {"ARMCLANG": "ARM", "GNUARM": "GCC_ARM"}

--- a/test/logs/NU_M2354/REGRESSION.log
+++ b/test/logs/NU_M2354/REGRESSION.log
@@ -1,0 +1,12 @@
+Non-secure test suites summary
+Test suite 'PSA protected storage NS interface tests \(TFM_PS_TEST_1XXX\)' has .* PASSED
+Test suite 'PSA internal trusted storage NS interface tests \(TFM_ITS_TEST_1XXX\)' has .* PASSED
+Test suite 'Crypto non-secure interface test \(TFM_CRYPTO_TEST_6XXX\)' has .* PASSED
+Test suite 'Platform Service Non-Secure interface tests\(TFM_PLATFORM_TEST_2XXX\)' has .* PASSED
+Test suite 'Initial Attestation Service non-secure interface tests\(TFM_ATTEST_TEST_2XXX\)' has .* PASSED
+Test suite 'QCBOR regression test\(TFM_QCBOR_TEST_7XXX\)' has .* PASSED
+Test suite 'T_COSE regression test\(TFM_T_COSE_TEST_8XXX\)' has .* PASSED
+Test suite 'PSA firmware update NS interface tests \(TFM_FWU_TEST_1xxx\)' has .* PASSED
+Test suite 'Core non-secure positive tests \(TFM_CORE_TEST_1XXX\)' has .* PASSED
+Test suite 'IPC non-secure interface test \(TFM_IPC_TEST_1XXX\)' has .* PASSED
+End of Non-secure test suites

--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -40,6 +40,32 @@
                 "dst": "targets/TARGET_ARM_SSG/TARGET_MUSCA_B1/partition/signing_layout_s.c"
             }
         ],
+        "NU_M2354": [
+            {
+                "src": "../platform/ext/target/nuvoton/m2354/partition/flash_layout.h",
+                "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/partition/flash_layout.h"
+            },
+            {
+                "src": "../platform/ext/target/nuvoton/m2354/partition/region_defs.h",
+                "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/partition/region_defs.h"
+            },
+            {
+                "src": "install/image_signing/layout_files/signing_layout_s.o",
+                "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/partition/signing_layout_s_preprocessed.h"
+            },
+            {
+                "src": "install/image_signing/layout_files/signing_layout_ns.o",
+                "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/partition/signing_layout_ns_preprocessed.h"
+            },
+            {
+                "src": "../bl2/ext/mcuboot/root-RSA-3072.pem",
+                "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/signing_key/nuvoton_m2354-root-rsa-3072.pem"
+            },
+            {
+                "src": "install/image_signing/keys/root-RSA-3072_1.pem",
+                "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/signing_key/nuvoton_m2354-root-rsa-3072_1.pem"
+            }
+        ],
         # List of files that should not be copied to Mbed OS even though they are covered by directory rules
         # in the next sections.
         # This feature keeps the yaml file small and tidy by allowing folder rules and list of files to be excluded.


### PR DESCRIPTION
This PR tries to upstream M2354 port to mainstream. It includes:

1.  Change trusted-firmware-m download path to Nuvoton forked repository (`nuvoton_mbed_m2354_tfm-1.3`) for M2354
1.  Add post-build copy paths specific to M2354 (`tfm_ns_import.yaml`)
1.  Detect python/python3 command name across platforms
1.  Enable Mbed CLI 2 (CMake)
1.  Enable Greentea test path
    1. Disable PSA compliance test, which M2354 hasn't supported yet
    1. Add compare log (REGRESSION.log only)

**NOTE1**: For upgrade to TF-M 1.4 for M2354, change branch to `nuvoton_mbed_m2354_tfm-1.4`.
**NOTE2**: About GCC toolchain, 9 2020-q2-update (and earlier)/10-2020-q4-major have issues on [-Os](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95646)/[-mcmse](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99157) respectively. This PR is verified with 10 2021.07.
**NOTE3**: If you run `TEST_S` tests, you will meet [TFM_SP_PS_TEST test broken](https://developer.trustedfirmware.org/T956) failure. It is caused by TFM_SP_PS_TEST stack overflow.