### PR TITLE
M2354: Add TF-M import partition_M2354.h

### DIFF
--- a/tfm_ns_import.yaml
+++ b/tfm_ns_import.yaml
@@ -46,6 +46,10 @@
                 "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/partition/flash_layout.h"
             },
             {
+                "src": "../platform/ext/target/nuvoton/m2354/partition/partition_M2354.h",
+                "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/partition/partition_M2354_im.h"
+            },
+            {
                 "src": "../platform/ext/target/nuvoton/m2354/partition/region_defs.h",
                 "dst": "targets/TARGET_NUVOTON/TARGET_M2354/TARGET_TFM/TARGET_NU_M2354/COMPONENT_TFM_S_FW/partition/region_defs.h"
             },


### PR DESCRIPTION
This PR, reflecting https://github.com/ARMmbed/mbed-os/pull/15029, adds `partition_M2354.h` into TF-M import list

