### PR TITLE
Revert "TEMP_COMMIT: point to mbed-os PR"

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/rwalton-arm/mbed-os/#TF-Mv1.4.0
+https://github.com/ARMmbed/mbed-os/


### PR DESCRIPTION
Revert accidentally merged temporary commit used for testing. We'd like
to use vanilla mbed-os from now on instead.

This reverts commit 71ff44ddc564a5d67a0cf94067045f003fd1352f.