### PR TITLE
Removed TFM_PERIPH_ACCESS_TEST in build_tfm.py

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -235,7 +235,6 @@ def _run_cmake_build(cmake_build_dir, args, tgt, tfm_config):
             [
                 "-DTEST_NS=ON",
                 "-DTEST_S=ON",
-                "-DTFM_PERIPH_ACCESS_TEST=ON",
             ]
         )
 


### PR DESCRIPTION
This test has been removed in the following versions of TF-m.