### PR TITLE
Added the -p option to choose the TF-m profile used for the build

### DIFF
--- a/build_tfm.py
+++ b/build_tfm.py
@@ -230,6 +230,9 @@ def _run_cmake_build(cmake_build_dir, args, tgt, tfm_config):
     cmake_cmd.append("-DTFM_PLATFORM=" + tgt[1])
     cmake_cmd.append("-DTFM_TOOLCHAIN_FILE=../toolchain_" + tgt[2] + ".cmake")
 
+    if args.profile:
+        cmake_cmd.append("-DTFM_PROFILE=" + args.profile.lower())
+
     if args.config == SUPPORTED_TFM_CONFIGS[1]:
         cmake_cmd.extend(
             [
@@ -689,6 +692,14 @@ def _get_parser():
         help=hmsg,
         default=None,
         choices=["ARMCLANG", "GNUARM"],
+    )
+
+    parser.add_argument(
+        "-p",
+        "--profile",
+        help="Build with the given TFM profile",
+        default=None,
+        choices=["PROFILE_LARGE", "PROFILE_MEDIUM", "PROFILE_SMALL"],
     )
 
     parser.add_argument(


### PR DESCRIPTION
- Useful to build for NUCLEO_L5
- Can be useful for other boards